### PR TITLE
feat: add Topbar, DashboardLayout, StatCard, and ShareInvoiceModal components 

### DIFF
--- a/src/app/(dashboard)/layout.tsx
+++ b/src/app/(dashboard)/layout.tsx
@@ -1,0 +1,20 @@
+import { Sidebar } from "@/components/Sidebar";
+import { Topbar } from "@/components/Topbar";
+
+export default function DashboardLayout({
+  children,
+}: {
+  children: React.ReactNode;
+}) {
+  return (
+    <div className="min-h-screen bg-background">
+      <Sidebar />
+      <Topbar />
+      <div className="ml-60 pt-16">
+        <main className="min-h-[calc(100vh-4rem)] overflow-y-auto p-6">
+          {children}
+        </main>
+      </div>
+    </div>
+  );
+}

--- a/src/app/dashboard/dashboard-actions.tsx
+++ b/src/app/dashboard/dashboard-actions.tsx
@@ -1,0 +1,31 @@
+"use client";
+
+import { useState } from "react";
+import { Share2 } from "lucide-react";
+
+import { Button } from "@/components/ui/button";
+import { ShareInvoiceModal } from "@/components/ShareInvoiceModal";
+
+export function DashboardActions() {
+  const [shareOpen, setShareOpen] = useState(false);
+
+  return (
+    <div className="mt-6">
+      <Button
+        variant="outline"
+        size="sm"
+        onClick={() => setShareOpen(true)}
+        className="gap-2"
+      >
+        <Share2 className="size-4" />
+        Share invoice
+      </Button>
+
+      <ShareInvoiceModal
+        invoiceId="INV-001"
+        isOpen={shareOpen}
+        onClose={() => setShareOpen(false)}
+      />
+    </div>
+  );
+}

--- a/src/app/dashboard/page.tsx
+++ b/src/app/dashboard/page.tsx
@@ -1,3 +1,10 @@
+import { DollarSign, FileText, TrendingUp, Users } from "lucide-react";
+
+import { Sidebar } from "@/components/Sidebar";
+import { Topbar } from "@/components/Topbar";
+import { StatCard } from "@/components/StatCard";
+import { DashboardActions } from "./dashboard-actions";
+
 export const metadata = {
   title: "Dashboard | Shade",
   description: "Shade merchant dashboard.",
@@ -5,16 +12,49 @@ export const metadata = {
 
 export default function DashboardPage() {
   return (
-    <main className="flex min-h-screen items-center justify-center bg-background px-6 py-12 text-foreground">
-      <section className="w-full max-w-xl rounded-lg border bg-card p-8 text-center shadow-sm">
-        <p className="text-sm font-semibold uppercase text-primary">
-          Shade merchant
-        </p>
-        <h1 className="mt-3 text-3xl font-bold">Dashboard coming next</h1>
-        <p className="mt-3 text-sm leading-6 text-muted-foreground">
-          Your wallet is verified and your merchant profile is ready.
-        </p>
-      </section>
-    </main>
+    <div className="min-h-screen bg-background">
+      <Sidebar />
+      <Topbar />
+
+      <div className="ml-60 pt-16">
+        <main className="min-h-[calc(100vh-4rem)] overflow-y-auto p-6">
+          <div className="mb-6">
+            <h1 className="text-2xl font-bold text-foreground">Dashboard</h1>
+            <p className="mt-1 text-sm text-muted-foreground">
+              Welcome back. Here&apos;s an overview of your business.
+            </p>
+          </div>
+
+          <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-4">
+            <StatCard
+              title="Total revenue"
+              value="$12,430"
+              icon={<DollarSign className="size-4" />}
+              trend={12.5}
+            />
+            <StatCard
+              title="Active invoices"
+              value="24"
+              icon={<FileText className="size-4" />}
+              trend={-3.2}
+            />
+            <StatCard
+              title="Total customers"
+              value="138"
+              icon={<Users className="size-4" />}
+              trend={8.1}
+            />
+            <StatCard
+              title="Payment volume"
+              value="$9,870"
+              icon={<TrendingUp className="size-4" />}
+              trend={5.4}
+            />
+          </div>
+
+          <DashboardActions />
+        </main>
+      </div>
+    </div>
   );
 }

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -80,6 +80,41 @@
 
 @custom-variant dark (&:is(.dark *));
 
+html.dark {
+  --background: oklch(0.15 0.04 255);
+  --foreground: oklch(0.97 0.012 248);
+  --card: oklch(0.19 0.045 255);
+  --card-foreground: oklch(0.97 0.012 248);
+  --popover: oklch(0.19 0.045 255);
+  --popover-foreground: oklch(0.97 0.012 248);
+  --primary: oklch(0.68 0.16 248);
+  --primary-foreground: oklch(0.14 0.05 255);
+  --secondary: oklch(0.27 0.065 255);
+  --secondary-foreground: oklch(0.95 0.018 250);
+  --muted: oklch(0.25 0.05 255);
+  --muted-foreground: oklch(0.76 0.055 252);
+  --accent: oklch(0.32 0.09 250);
+  --accent-foreground: oklch(0.96 0.018 250);
+  --destructive: oklch(0.62 0.2 25);
+  --destructive-foreground: oklch(0.98 0.01 25);
+  --border: oklch(1 0 0 / 12%);
+  --input: oklch(1 0 0 / 16%);
+  --ring: oklch(0.68 0.16 248);
+  --chart-1: oklch(0.68 0.16 248);
+  --chart-2: oklch(0.72 0.14 220);
+  --chart-3: oklch(0.73 0.13 185);
+  --chart-4: oklch(0.72 0.14 145);
+  --chart-5: oklch(0.74 0.15 285);
+  --sidebar: oklch(0.18 0.045 255);
+  --sidebar-foreground: oklch(0.97 0.012 248);
+  --sidebar-primary: oklch(0.68 0.16 248);
+  --sidebar-primary-foreground: oklch(0.14 0.05 255);
+  --sidebar-accent: oklch(0.32 0.09 250);
+  --sidebar-accent-foreground: oklch(0.96 0.018 250);
+  --sidebar-border: oklch(1 0 0 / 12%);
+  --sidebar-ring: oklch(0.68 0.16 248);
+}
+
 @media (prefers-color-scheme: dark) {
   :root {
     --background: oklch(0.15 0.04 255);

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,6 +1,7 @@
 import type { Metadata } from "next";
 import { Geist, Geist_Mono } from "next/font/google";
 import "./globals.css";
+import { ThemeProvider } from "@/components/ThemeProvider";
 
 const geistSans = Geist({
   variable: "--font-geist-sans",
@@ -27,7 +28,7 @@ export default function RootLayout({
       <body
         className={`${geistSans.variable} ${geistMono.variable} antialiased`}
       >
-        {children}
+        <ThemeProvider>{children}</ThemeProvider>
       </body>
     </html>
   );

--- a/src/components/ShareInvoiceModal.tsx
+++ b/src/components/ShareInvoiceModal.tsx
@@ -1,0 +1,96 @@
+"use client";
+
+import { useState } from "react";
+import { Check, Copy, X } from "lucide-react";
+
+import { cn } from "@/lib/utils";
+
+type ShareInvoiceModalProps = {
+  invoiceId: string;
+  isOpen: boolean;
+  onClose: () => void;
+};
+
+export function ShareInvoiceModal({
+  invoiceId,
+  isOpen,
+  onClose,
+}: ShareInvoiceModalProps) {
+  const [copied, setCopied] = useState(false);
+  const url = `https://shade.app/pay/${invoiceId}`;
+
+  async function handleCopy() {
+    await navigator.clipboard.writeText(url);
+    setCopied(true);
+    setTimeout(() => setCopied(false), 2000);
+  }
+
+  if (!isOpen) return null;
+
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center p-4">
+      <div
+        className="absolute inset-0 bg-black/50 backdrop-blur-sm"
+        onClick={onClose}
+        aria-hidden="true"
+      />
+
+      <div
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby="share-invoice-title"
+        className="relative z-10 w-full max-w-md rounded-lg border bg-card p-6 shadow-lg"
+      >
+        <div className="mb-5 flex items-start justify-between gap-4">
+          <div>
+            <h2
+              id="share-invoice-title"
+              className="text-base font-semibold text-card-foreground"
+            >
+              Share invoice
+            </h2>
+            <p className="mt-1 text-sm text-muted-foreground">
+              Send this link to your customer to complete payment.
+            </p>
+          </div>
+
+          <button
+            onClick={onClose}
+            aria-label="Close"
+            className="inline-flex size-8 shrink-0 items-center justify-center rounded-md text-muted-foreground transition-colors hover:bg-accent hover:text-accent-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+          >
+            <X className="size-4" />
+          </button>
+        </div>
+
+        <div className="flex items-center gap-2 rounded-md border bg-muted/40 px-3 py-2.5">
+          <span className="min-w-0 flex-1 truncate font-mono text-sm text-foreground">
+            {url}
+          </span>
+
+          <button
+            onClick={handleCopy}
+            className={cn(
+              "inline-flex shrink-0 items-center gap-1.5 rounded px-2.5 py-1 text-xs font-semibold transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring",
+              copied
+                ? "bg-green-100 text-green-700 dark:bg-green-900/40 dark:text-green-400"
+                : "bg-primary text-primary-foreground hover:bg-primary/90",
+            )}
+          >
+            {copied ? (
+              <>
+                <Check className="size-3.5" />
+                Copied!
+              </>
+            ) : (
+              <>
+                <Copy className="size-3.5" />
+                Copy
+              </>
+            )}
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -1,0 +1,74 @@
+"use client";
+
+import Link from "next/link";
+import Image from "next/image";
+import { usePathname } from "next/navigation";
+import {
+  FileText,
+  LayoutDashboard,
+  LogOut,
+  Settings,
+  Users,
+} from "lucide-react";
+
+import { cn } from "@/lib/utils";
+
+const navItems = [
+  { href: "/dashboard", label: "Dashboard", icon: LayoutDashboard },
+  { href: "/invoices", label: "Invoices", icon: FileText },
+  { href: "/customers", label: "Customers", icon: Users },
+  { href: "/settings", label: "Settings", icon: Settings },
+];
+
+export function Sidebar() {
+  const pathname = usePathname();
+
+  return (
+    <aside className="fixed inset-y-0 left-0 z-40 flex w-60 flex-col border-r bg-sidebar">
+      <div className="flex h-16 shrink-0 items-center gap-2.5 border-b px-5">
+        <Image
+          src="/shade_logo_transparent.png"
+          alt="Shade"
+          width={28}
+          height={28}
+          className="shrink-0"
+        />
+        <span className="text-base font-bold text-sidebar-foreground">
+          Shade
+        </span>
+      </div>
+
+      <nav className="flex-1 overflow-y-auto px-3 py-4">
+        <ul className="flex flex-col gap-0.5">
+          {navItems.map(({ href, label, icon: Icon }) => {
+            const active =
+              pathname === href || pathname.startsWith(href + "/");
+            return (
+              <li key={href}>
+                <Link
+                  href={href}
+                  className={cn(
+                    "flex items-center gap-3 rounded-md px-3 py-2 text-sm font-medium transition-colors",
+                    active
+                      ? "bg-sidebar-accent text-sidebar-accent-foreground"
+                      : "text-sidebar-foreground hover:bg-sidebar-accent/60 hover:text-sidebar-accent-foreground",
+                  )}
+                >
+                  <Icon className="size-4 shrink-0" />
+                  {label}
+                </Link>
+              </li>
+            );
+          })}
+        </ul>
+      </nav>
+
+      <div className="shrink-0 border-t px-3 py-3">
+        <button className="flex w-full items-center gap-3 rounded-md px-3 py-2 text-sm font-medium text-muted-foreground transition-colors hover:bg-sidebar-accent/60 hover:text-sidebar-accent-foreground">
+          <LogOut className="size-4 shrink-0" />
+          Sign out
+        </button>
+      </div>
+    </aside>
+  );
+}

--- a/src/components/StatCard.tsx
+++ b/src/components/StatCard.tsx
@@ -1,0 +1,47 @@
+import { TrendingDown, TrendingUp } from "lucide-react";
+
+import { cn } from "@/lib/utils";
+
+type StatCardProps = {
+  title: string;
+  value: string | number;
+  icon: React.ReactNode;
+  trend: number;
+};
+
+export function StatCard({ title, value, icon, trend }: StatCardProps) {
+  const isPositive = trend >= 0;
+
+  return (
+    <div className="rounded-lg border bg-card p-5 shadow-sm">
+      <div className="flex items-start justify-between">
+        <p className="text-sm font-medium text-muted-foreground">{title}</p>
+        <div className="flex size-9 items-center justify-center rounded-md bg-primary/10 text-primary">
+          {icon}
+        </div>
+      </div>
+
+      <p className="mt-3 text-2xl font-bold text-foreground">{value}</p>
+
+      <div
+        className={cn(
+          "mt-2 flex items-center gap-1 text-xs font-medium",
+          isPositive
+            ? "text-green-600 dark:text-green-400"
+            : "text-red-600 dark:text-red-400",
+        )}
+      >
+        {isPositive ? (
+          <TrendingUp className="size-3.5 shrink-0" />
+        ) : (
+          <TrendingDown className="size-3.5 shrink-0" />
+        )}
+        <span>
+          {isPositive ? "+" : ""}
+          {trend}%
+        </span>
+        <span className="font-normal text-muted-foreground">vs last month</span>
+      </div>
+    </div>
+  );
+}

--- a/src/components/ThemeProvider.tsx
+++ b/src/components/ThemeProvider.tsx
@@ -1,0 +1,42 @@
+"use client";
+
+import { createContext, useContext, useEffect, useState } from "react";
+
+type ThemeContextValue = {
+  isDark: boolean;
+  toggleTheme: () => void;
+};
+
+const ThemeContext = createContext<ThemeContextValue>({
+  isDark: false,
+  toggleTheme: () => {},
+});
+
+export function ThemeProvider({ children }: { children: React.ReactNode }) {
+  const [isDark, setIsDark] = useState(false);
+
+  useEffect(() => {
+    const stored = localStorage.getItem("shade:theme");
+    const systemDark = window.matchMedia("(prefers-color-scheme: dark)").matches;
+    const dark = stored === "dark" || (stored !== "light" && systemDark);
+    setIsDark(dark);
+    document.documentElement.classList.toggle("dark", dark);
+  }, []);
+
+  function toggleTheme() {
+    const next = !isDark;
+    setIsDark(next);
+    document.documentElement.classList.toggle("dark", next);
+    localStorage.setItem("shade:theme", next ? "dark" : "light");
+  }
+
+  return (
+    <ThemeContext.Provider value={{ isDark, toggleTheme }}>
+      {children}
+    </ThemeContext.Provider>
+  );
+}
+
+export function useTheme() {
+  return useContext(ThemeContext);
+}

--- a/src/components/Topbar.tsx
+++ b/src/components/Topbar.tsx
@@ -1,0 +1,46 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { Moon, Sun, Wallet } from "lucide-react";
+
+import { useTheme } from "@/components/ThemeProvider";
+import { getMerchantSessionAddress } from "@/lib/merchant-storage";
+
+function truncateAddress(address: string): string {
+  if (address.length <= 10) return address;
+  return `${address.slice(0, 4)}...${address.slice(-4)}`;
+}
+
+export function Topbar() {
+  const { isDark, toggleTheme } = useTheme();
+  const [walletAddress, setWalletAddress] = useState<string | null>(null);
+
+  useEffect(() => {
+    setWalletAddress(getMerchantSessionAddress());
+  }, []);
+
+  return (
+    <header className="fixed inset-x-0 top-0 z-30 ml-60 flex h-16 items-center justify-between border-b bg-background px-6">
+      <div />
+
+      <div className="flex items-center gap-3">
+        {walletAddress ? (
+          <div className="flex items-center gap-2 rounded-md border bg-secondary/60 px-3 py-1.5">
+            <Wallet className="size-3.5 shrink-0 text-muted-foreground" />
+            <span className="font-mono text-xs font-medium text-secondary-foreground">
+              {truncateAddress(walletAddress)}
+            </span>
+          </div>
+        ) : null}
+
+        <button
+          onClick={toggleTheme}
+          aria-label="Toggle theme"
+          className="inline-flex size-9 items-center justify-center rounded-md border bg-background text-muted-foreground transition-colors hover:bg-accent hover:text-accent-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background"
+        >
+          {isDark ? <Sun className="size-4" /> : <Moon className="size-4" />}
+        </button>
+      </div>
+    </header>
+  );
+}


### PR DESCRIPTION

closes #11 closes #12 closes #14 closes #30

## Summary

- Implements a horizontal Topbar (issue #11) that displays the merchant's truncated Stellar wallet address read from sessionStorage and a Dark/Light theme toggle backed by a new ThemeProvider and `html.dark` CSS class overrides.
- Creates a `DashboardLayout` at `src/app/(dashboard)/layout.tsx` (issue #12) that composes the fixed Sidebar and Topbar around a scrollable `children` area; all authenticated routes added inside `app/(dashboard)/` inherit this layout.
- Adds a reusable `StatCard` component (issue #14) with title, value, icon, and trend props; positive trends render green, negative red.
- Adds a `ShareInvoiceModal` component (issue #30) with a generated payment URL display, a clipboard Copy button with "Copied!" feedback, and accessible dialog markup.

## Changes

- `src/app/globals.css` — added `html.dark { … }` block (same variable values as the media-query dark block) so the manual toggle overrides system preference without removing the automatic fallback.
- `src/app/layout.tsx` — wraps the app in `ThemeProvider`.
- `src/components/ThemeProvider.tsx` — client context; initialises theme from localStorage on mount, toggles `html.dark` class and persists choice.
- `src/components/Sidebar.tsx` — fixed 240 px sidebar with logo, four nav links (active-state via `usePathname`), and a sign-out button; uses `--sidebar-*` design tokens.
- `src/components/Topbar.tsx` — fixed topbar offset by sidebar width; wallet address with `Wallet` icon, theme toggle button.
- `src/app/(dashboard)/layout.tsx` — Next.js route-group layout composing Sidebar + Topbar + scrollable main.
- `src/components/StatCard.tsx` — server component; renders KPI card with conditional trend colour.
- `src/components/ShareInvoiceModal.tsx` — client component; modal with backdrop, URL display, clipboard copy, and accessible ARIA attributes.
- `src/app/dashboard/page.tsx` — updated from placeholder to a real dashboard with four StatCards and the layout structure.
- `src/app/dashboard/dashboard-actions.tsx` — thin client component that owns the share-modal open/close state.

## Test plan

- [ ] `/dashboard` renders with a fixed sidebar on the left and topbar at the top.
- [ ] Topbar shows a truncated wallet address (e.g. `GABC...1234`) when a session exists in sessionStorage.
- [ ] Theme toggle switches between light and dark; preference survives a page refresh.
- [ ] All four StatCards render with correct values; positive trend shows green, negative shows red.
- [ ] "Share invoice" button opens the modal; the URL `https://shade.app/pay/INV-001` is displayed.
- [ ] Copy button copies the URL and shows "Copied!" for ~2 s, then resets.
- [ ] Clicking the backdrop or the X button closes the modal.
- [ ] A new page added inside `src/app/(dashboard)/` automatically inherits the Sidebar and Topbar via the route-group layout.
