### PR TITLE
feat: InvoiceTable, Generate Invoice submit, SettingsLayout, Pay with Connected Wallet view

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -336,21 +336,6 @@
         }
       }
     },
-    "node_modules/@creit.tech/stellar-wallets-kit/node_modules/typescript": {
-      "version": "4.9.5",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.9.5.tgz",
-      "integrity": "sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==",
-      "license": "Apache-2.0",
-      "optional": true,
-      "peer": true,
-      "bin": {
-        "tsc": "bin/tsc",
-        "tsserver": "bin/tsserver"
-      },
-      "engines": {
-        "node": ">=4.2.0"
-      }
-    },
     "node_modules/@creit.tech/xbull-wallet-connect": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/@creit.tech/xbull-wallet-connect/-/xbull-wallet-connect-0.4.0.tgz",
@@ -7398,21 +7383,6 @@
         "ws": "^7.5.1"
       }
     },
-    "node_modules/@walletconnect/jsonrpc-ws-connection/node_modules/utf-8-validate": {
-      "version": "5.0.10",
-      "resolved": "https://registry.npmjs.org/utf-8-validate/-/utf-8-validate-5.0.10.tgz",
-      "integrity": "sha512-Z6czzLq4u8fPOyx7TU6X3dvUZVvoJmxSQ+IcrlmagKhilxlhZgxPK6C5Jqbkw1IDUmFTM+cz9QDnnLTwDz/2gQ==",
-      "hasInstallScript": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "node-gyp-build": "^4.3.0"
-      },
-      "engines": {
-        "node": ">=6.14.2"
-      }
-    },
     "node_modules/@walletconnect/jsonrpc-ws-connection/node_modules/ws": {
       "version": "7.5.10",
       "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.10.tgz",
@@ -11561,21 +11531,6 @@
       "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
       "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
       "license": "MIT"
-    },
-    "node_modules/jayson/node_modules/utf-8-validate": {
-      "version": "5.0.10",
-      "resolved": "https://registry.npmjs.org/utf-8-validate/-/utf-8-validate-5.0.10.tgz",
-      "integrity": "sha512-Z6czzLq4u8fPOyx7TU6X3dvUZVvoJmxSQ+IcrlmagKhilxlhZgxPK6C5Jqbkw1IDUmFTM+cz9QDnnLTwDz/2gQ==",
-      "hasInstallScript": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "node-gyp-build": "^4.3.0"
-      },
-      "engines": {
-        "node": ">=6.14.2"
-      }
     },
     "node_modules/jayson/node_modules/ws": {
       "version": "7.5.10",

--- a/src/app/invoices/invoices-client.tsx
+++ b/src/app/invoices/invoices-client.tsx
@@ -1,0 +1,44 @@
+"use client";
+
+import { useState } from "react";
+
+import { InvoiceForm } from "@/components/invoice/invoice-form";
+import { InvoiceTable } from "@/components/invoice/invoice-table";
+import type { Invoice } from "@/lib/invoice-types";
+
+const seedInvoices: Invoice[] = [
+  {
+    referenceId: "INV-DEMO-001",
+    description: "Brand identity refresh",
+    amount: "450.00",
+    token: "USDC",
+    status: "paid",
+    createdAt: "2026-05-12T14:30:00.000Z",
+  },
+  {
+    referenceId: "INV-DEMO-002",
+    description: "May retainer",
+    amount: "1200.00",
+    token: "XLM",
+    status: "pending",
+    createdAt: "2026-05-20T09:05:00.000Z",
+  },
+];
+
+export function InvoicesClient() {
+  const [invoices, setInvoices] = useState<Invoice[]>(seedInvoices);
+
+  return (
+    <div className="flex flex-col gap-8">
+      <InvoiceForm
+        onSubmit={(invoice) =>
+          setInvoices((current) => [invoice, ...current])
+        }
+      />
+      <section className="space-y-3">
+        <h2 className="text-lg font-semibold">Your invoices</h2>
+        <InvoiceTable invoices={invoices} />
+      </section>
+    </div>
+  );
+}

--- a/src/app/invoices/page.tsx
+++ b/src/app/invoices/page.tsx
@@ -1,0 +1,22 @@
+import { InvoicesClient } from "./invoices-client";
+
+export const metadata = {
+  title: "Invoices | Shade",
+  description: "Generate and review your Shade invoices.",
+};
+
+export default function InvoicesPage() {
+  return (
+    <main className="min-h-screen bg-background px-6 py-12 text-foreground">
+      <div className="mx-auto w-full max-w-5xl space-y-8">
+        <header className="space-y-1">
+          <p className="text-sm font-semibold uppercase text-primary">
+            Shade merchant
+          </p>
+          <h1 className="text-3xl font-bold">Invoices</h1>
+        </header>
+        <InvoicesClient />
+      </div>
+    </main>
+  );
+}

--- a/src/app/pay/page.tsx
+++ b/src/app/pay/page.tsx
@@ -1,0 +1,25 @@
+import { PayTabs } from "@/components/pay/pay-tabs";
+
+export const metadata = {
+  title: "Pay invoice | Shade",
+  description: "Settle a Shade invoice with your Stellar wallet.",
+};
+
+export default function PayPage() {
+  return (
+    <main className="min-h-screen bg-background px-6 py-12 text-foreground">
+      <div className="mx-auto w-full max-w-3xl space-y-6">
+        <header className="space-y-1">
+          <p className="text-sm font-semibold uppercase text-primary">
+            Shade
+          </p>
+          <h1 className="text-3xl font-bold">Pay invoice</h1>
+          <p className="text-sm text-muted-foreground">
+            Choose how you want to settle this invoice.
+          </p>
+        </header>
+        <PayTabs />
+      </div>
+    </main>
+  );
+}

--- a/src/app/settings/api-keys/page.tsx
+++ b/src/app/settings/api-keys/page.tsx
@@ -1,0 +1,20 @@
+export const metadata = {
+  title: "API Keys · Settings | Shade",
+};
+
+export default function ApiKeysSettingsPage() {
+  return (
+    <div className="space-y-4">
+      <div>
+        <h2 className="text-xl font-semibold">API Keys</h2>
+        <p className="text-sm text-muted-foreground">
+          Programmatic access for your Shade integration.
+        </p>
+      </div>
+      <p className="text-sm text-muted-foreground">
+        Key generation will land here. You will be able to issue, rotate, and
+        revoke keys used by your server to call Shade.
+      </p>
+    </div>
+  );
+}

--- a/src/app/settings/layout.tsx
+++ b/src/app/settings/layout.tsx
@@ -1,0 +1,33 @@
+import type { Metadata } from "next";
+
+import { SettingsNav } from "@/components/settings/settings-nav";
+
+export const metadata: Metadata = {
+  title: "Settings | Shade",
+  description: "Manage your Shade merchant profile and API keys.",
+};
+
+export default function SettingsLayout({
+  children,
+}: {
+  children: React.ReactNode;
+}) {
+  return (
+    <main className="min-h-screen bg-background px-6 py-12 text-foreground">
+      <div className="mx-auto w-full max-w-5xl space-y-8">
+        <header className="space-y-1">
+          <p className="text-sm font-semibold uppercase text-primary">
+            Shade merchant
+          </p>
+          <h1 className="text-3xl font-bold">Settings</h1>
+        </header>
+        <div className="flex flex-col gap-6 md:flex-row md:items-start">
+          <SettingsNav />
+          <section className="min-w-0 flex-1 rounded-lg border bg-card p-6 shadow-sm">
+            {children}
+          </section>
+        </div>
+      </div>
+    </main>
+  );
+}

--- a/src/app/settings/page.tsx
+++ b/src/app/settings/page.tsx
@@ -1,0 +1,5 @@
+import { redirect } from "next/navigation";
+
+export default function SettingsIndexPage() {
+  redirect("/settings/profile");
+}

--- a/src/app/settings/profile/page.tsx
+++ b/src/app/settings/profile/page.tsx
@@ -1,0 +1,20 @@
+export const metadata = {
+  title: "Profile · Settings | Shade",
+};
+
+export default function ProfileSettingsPage() {
+  return (
+    <div className="space-y-4">
+      <div>
+        <h2 className="text-xl font-semibold">Profile</h2>
+        <p className="text-sm text-muted-foreground">
+          Personal and business details visible to your customers.
+        </p>
+      </div>
+      <p className="text-sm text-muted-foreground">
+        Profile editing is coming next. This section will let you update your
+        name, business details, and verified email.
+      </p>
+    </div>
+  );
+}

--- a/src/components/invoice/invoice-form.tsx
+++ b/src/components/invoice/invoice-form.tsx
@@ -1,0 +1,182 @@
+"use client";
+
+import { FormEvent, useState } from "react";
+import { Loader2 } from "lucide-react";
+
+import { Button } from "@/components/ui/button";
+import type { Invoice } from "@/lib/invoice-types";
+
+const tokenOptions = ["XLM", "USDC", "EURC"] as const;
+
+type InvoiceDraft = {
+  description: string;
+  amount: string;
+  token: (typeof tokenOptions)[number];
+};
+
+const initialDraft: InvoiceDraft = {
+  description: "",
+  amount: "",
+  token: "XLM",
+};
+
+function generateReference() {
+  const random = Math.random().toString(36).slice(2, 8).toUpperCase();
+  return `INV-${Date.now().toString(36).toUpperCase()}-${random}`;
+}
+
+function isAmountValid(value: string) {
+  if (!value.trim()) return false;
+  const numeric = Number(value);
+  return Number.isFinite(numeric) && numeric > 0;
+}
+
+export type InvoiceFormProps = {
+  onSubmit?: (invoice: Invoice) => Promise<void> | void;
+};
+
+export function InvoiceForm({ onSubmit }: InvoiceFormProps) {
+  const [draft, setDraft] = useState<InvoiceDraft>(initialDraft);
+  const [isSubmitting, setIsSubmitting] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [createdInvoice, setCreatedInvoice] = useState<Invoice | null>(null);
+
+  const canSubmit =
+    draft.description.trim().length > 0 && isAmountValid(draft.amount);
+
+  function updateField<K extends keyof InvoiceDraft>(
+    field: K,
+    value: InvoiceDraft[K],
+  ) {
+    setError(null);
+    setDraft((current) => ({ ...current, [field]: value }));
+  }
+
+  async function handleSubmit(event: FormEvent<HTMLFormElement>) {
+    event.preventDefault();
+
+    if (!canSubmit || isSubmitting) return;
+
+    const invoice: Invoice = {
+      referenceId: generateReference(),
+      description: draft.description.trim(),
+      amount: Number(draft.amount).toFixed(2),
+      token: draft.token,
+      status: "pending",
+      createdAt: new Date().toISOString(),
+    };
+
+    setIsSubmitting(true);
+    setError(null);
+
+    try {
+      await onSubmit?.(invoice);
+      setCreatedInvoice(invoice);
+      setDraft(initialDraft);
+    } catch (caught) {
+      setError(
+        caught instanceof Error
+          ? caught.message
+          : "Unable to generate invoice. Please try again.",
+      );
+    } finally {
+      setIsSubmitting(false);
+    }
+  }
+
+  return (
+    <form
+      onSubmit={handleSubmit}
+      className="flex w-full max-w-xl flex-col gap-5 rounded-lg border bg-card p-6 shadow-sm"
+      noValidate
+    >
+      <div className="space-y-1">
+        <h2 className="text-xl font-semibold">Generate invoice</h2>
+        <p className="text-sm text-muted-foreground">
+          Create a payable invoice your customer can settle on Stellar.
+        </p>
+      </div>
+
+      <label className="flex flex-col gap-1.5 text-sm">
+        <span className="font-medium">Description</span>
+        <textarea
+          required
+          rows={3}
+          value={draft.description}
+          onChange={(event) => updateField("description", event.target.value)}
+          className="rounded-md border bg-background px-3 py-2 text-sm shadow-sm focus:outline-none focus:ring-2 focus:ring-ring"
+          placeholder="What is this invoice for?"
+          disabled={isSubmitting}
+        />
+      </label>
+
+      <div className="grid grid-cols-1 gap-4 sm:grid-cols-2">
+        <label className="flex flex-col gap-1.5 text-sm">
+          <span className="font-medium">Amount</span>
+          <input
+            required
+            type="number"
+            inputMode="decimal"
+            min="0"
+            step="0.01"
+            value={draft.amount}
+            onChange={(event) => updateField("amount", event.target.value)}
+            className="rounded-md border bg-background px-3 py-2 text-sm shadow-sm focus:outline-none focus:ring-2 focus:ring-ring"
+            placeholder="0.00"
+            disabled={isSubmitting}
+          />
+        </label>
+
+        <label className="flex flex-col gap-1.5 text-sm">
+          <span className="font-medium">Token</span>
+          <select
+            value={draft.token}
+            onChange={(event) =>
+              updateField("token", event.target.value as InvoiceDraft["token"])
+            }
+            className="rounded-md border bg-background px-3 py-2 text-sm shadow-sm focus:outline-none focus:ring-2 focus:ring-ring"
+            disabled={isSubmitting}
+          >
+            {tokenOptions.map((token) => (
+              <option key={token} value={token}>
+                {token}
+              </option>
+            ))}
+          </select>
+        </label>
+      </div>
+
+      {error ? (
+        <p role="alert" className="text-sm text-destructive">
+          {error}
+        </p>
+      ) : null}
+
+      {createdInvoice ? (
+        <p
+          role="status"
+          className="rounded-md border border-emerald-300 bg-emerald-50 px-3 py-2 text-sm text-emerald-900"
+        >
+          Invoice <span className="font-mono">{createdInvoice.referenceId}</span>{" "}
+          generated.
+        </p>
+      ) : null}
+
+      <Button
+        type="submit"
+        disabled={!canSubmit || isSubmitting}
+        aria-busy={isSubmitting}
+        className="self-start"
+      >
+        {isSubmitting ? (
+          <>
+            <Loader2 className="animate-spin" aria-hidden />
+            <span>Generating…</span>
+          </>
+        ) : (
+          "Generate invoice"
+        )}
+      </Button>
+    </form>
+  );
+}

--- a/src/components/invoice/invoice-table.tsx
+++ b/src/components/invoice/invoice-table.tsx
@@ -1,0 +1,108 @@
+import { cn } from "@/lib/utils";
+import type { Invoice, InvoiceStatus } from "@/lib/invoice-types";
+
+const statusStyles: Record<InvoiceStatus, string> = {
+  draft: "bg-muted text-muted-foreground",
+  pending: "bg-amber-100 text-amber-900",
+  paid: "bg-emerald-100 text-emerald-900",
+  overdue: "bg-rose-100 text-rose-900",
+  cancelled: "bg-zinc-200 text-zinc-700",
+};
+
+const statusLabels: Record<InvoiceStatus, string> = {
+  draft: "Draft",
+  pending: "Pending",
+  paid: "Paid",
+  overdue: "Overdue",
+  cancelled: "Cancelled",
+};
+
+function formatCreatedAt(value: string) {
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) return value;
+  return date.toLocaleDateString(undefined, {
+    year: "numeric",
+    month: "short",
+    day: "2-digit",
+  });
+}
+
+type InvoiceTableProps = {
+  invoices: Invoice[];
+  className?: string;
+  emptyState?: React.ReactNode;
+};
+
+export function InvoiceTable({ invoices, className, emptyState }: InvoiceTableProps) {
+  return (
+    <div
+      className={cn(
+        "relative w-full overflow-x-auto rounded-lg border bg-card shadow-sm",
+        className,
+      )}
+    >
+      <table className="w-full min-w-[720px] border-collapse text-left text-sm">
+        <thead className="sticky top-0 z-10 bg-muted text-muted-foreground">
+          <tr>
+            <th scope="col" className="px-4 py-3 font-semibold">
+              Reference ID
+            </th>
+            <th scope="col" className="px-4 py-3 font-semibold">
+              Description
+            </th>
+            <th scope="col" className="px-4 py-3 font-semibold">
+              Amount / Token
+            </th>
+            <th scope="col" className="px-4 py-3 font-semibold">
+              Status
+            </th>
+            <th scope="col" className="px-4 py-3 font-semibold">
+              Created
+            </th>
+          </tr>
+        </thead>
+        <tbody>
+          {invoices.length === 0 ? (
+            <tr>
+              <td
+                colSpan={5}
+                className="px-4 py-12 text-center text-sm text-muted-foreground"
+              >
+                {emptyState ?? "No invoices to display."}
+              </td>
+            </tr>
+          ) : (
+            invoices.map((invoice) => (
+              <tr
+                key={invoice.referenceId}
+                className="border-t hover:bg-muted/40"
+              >
+                <td className="px-4 py-3 font-mono text-xs">
+                  {invoice.referenceId}
+                </td>
+                <td className="px-4 py-3">{invoice.description}</td>
+                <td className="px-4 py-3 tabular-nums">
+                  {invoice.amount}{" "}
+                  <span className="text-muted-foreground">{invoice.token}</span>
+                </td>
+                <td className="px-4 py-3">
+                  <span
+                    className={cn(
+                      "inline-flex rounded-full px-2.5 py-1 text-xs font-medium",
+                      statusStyles[invoice.status],
+                    )}
+                  >
+                    {statusLabels[invoice.status]}
+                  </span>
+                </td>
+                <td className="px-4 py-3 text-muted-foreground">
+                  {formatCreatedAt(invoice.createdAt)}
+                </td>
+              </tr>
+            ))
+          )}
+        </tbody>
+      </table>
+    </div>
+  );
+}

--- a/src/components/pay/pay-tabs.tsx
+++ b/src/components/pay/pay-tabs.tsx
@@ -1,0 +1,62 @@
+"use client";
+
+import { useState } from "react";
+
+import { cn } from "@/lib/utils";
+import { PayWithConnectedWalletView } from "./pay-with-connected-wallet-view";
+
+type PayTab = "connected-wallet" | "manual-transfer";
+
+const tabs: Array<{ id: PayTab; label: string }> = [
+  { id: "connected-wallet", label: "Pay with Connected Wallet" },
+  { id: "manual-transfer", label: "Manual transfer" },
+];
+
+export function PayTabs() {
+  const [activeTab, setActiveTab] = useState<PayTab>("connected-wallet");
+
+  return (
+    <div className="flex w-full max-w-2xl flex-col gap-4">
+      <div role="tablist" aria-label="Payment method" className="flex gap-2 border-b">
+        {tabs.map(({ id, label }) => (
+          <button
+            key={id}
+            role="tab"
+            type="button"
+            id={`pay-tab-${id}`}
+            aria-selected={activeTab === id}
+            aria-controls={`pay-panel-${id}`}
+            onClick={() => setActiveTab(id)}
+            className={cn(
+              "rounded-t-md px-4 py-2 text-sm font-medium transition-colors",
+              activeTab === id
+                ? "border-b-2 border-primary text-primary"
+                : "text-muted-foreground hover:text-foreground",
+            )}
+          >
+            {label}
+          </button>
+        ))}
+      </div>
+
+      <div
+        role="tabpanel"
+        id="pay-panel-connected-wallet"
+        aria-labelledby="pay-tab-connected-wallet"
+        hidden={activeTab !== "connected-wallet"}
+      >
+        <PayWithConnectedWalletView />
+      </div>
+
+      <div
+        role="tabpanel"
+        id="pay-panel-manual-transfer"
+        aria-labelledby="pay-tab-manual-transfer"
+        hidden={activeTab !== "manual-transfer"}
+        className="rounded-lg border bg-card p-6 text-sm text-muted-foreground"
+      >
+        Manual transfer instructions will appear here.
+      </div>
+    </div>
+  );
+}

--- a/src/components/pay/pay-with-connected-wallet-view.tsx
+++ b/src/components/pay/pay-with-connected-wallet-view.tsx
@@ -1,0 +1,90 @@
+"use client";
+
+import { useState } from "react";
+import { CheckCircle2, Loader2, WalletCards } from "lucide-react";
+
+import { Button } from "@/components/ui/button";
+
+type ConnectionStatus = "idle" | "connecting" | "connected";
+
+export function PayWithConnectedWalletView() {
+  const [status, setStatus] = useState<ConnectionStatus>("idle");
+
+  async function handleConnect() {
+    if (status !== "idle") return;
+    setStatus("connecting");
+    // Mocked wallet handshake — real Stellar wallet wiring lands in a follow-up.
+    await new Promise((resolve) => setTimeout(resolve, 900));
+    setStatus("connected");
+  }
+
+  return (
+    <section className="flex flex-col gap-6 rounded-lg border bg-card p-6 shadow-sm">
+      <header className="space-y-2">
+        <div className="flex items-center gap-2 text-primary">
+          <WalletCards className="size-5" aria-hidden />
+          <h2 className="text-lg font-semibold text-foreground">
+            Pay with your connected wallet
+          </h2>
+        </div>
+        <p className="text-sm text-muted-foreground">
+          This is the fastest, automated way to settle this invoice. Connect a
+          Stellar wallet (Freighter, Albedo, xBull…), approve the prepared
+          payment in the wallet popup, and Shade will detect the on-chain
+          settlement automatically — no copying addresses, memos, or amounts.
+        </p>
+      </header>
+
+      <ol className="space-y-2 text-sm text-muted-foreground">
+        <li>
+          <span className="font-medium text-foreground">1.</span> Click{" "}
+          <span className="font-medium text-foreground">Connect Wallet</span>{" "}
+          and pick your Stellar wallet.
+        </li>
+        <li>
+          <span className="font-medium text-foreground">2.</span> Review the
+          pre-filled payment in the wallet popup.
+        </li>
+        <li>
+          <span className="font-medium text-foreground">3.</span> Approve — the
+          invoice marks paid as soon as the transaction confirms.
+        </li>
+      </ol>
+
+      <Button
+        type="button"
+        onClick={handleConnect}
+        disabled={status !== "idle"}
+        aria-busy={status === "connecting"}
+        className="self-start"
+      >
+        {status === "connecting" ? (
+          <>
+            <Loader2 className="animate-spin" aria-hidden />
+            <span>Connecting wallet…</span>
+          </>
+        ) : status === "connected" ? (
+          <>
+            <CheckCircle2 aria-hidden />
+            <span>Wallet connected</span>
+          </>
+        ) : (
+          <>
+            <WalletCards aria-hidden />
+            <span>Connect Wallet</span>
+          </>
+        )}
+      </Button>
+
+      {status === "connected" ? (
+        <p
+          role="status"
+          className="rounded-md border border-emerald-300 bg-emerald-50 px-3 py-2 text-sm text-emerald-900"
+        >
+          Mock wallet connected. The real payment confirmation flow ships with
+          the wallet-integration task.
+        </p>
+      ) : null}
+    </section>
+  );
+}

--- a/src/components/settings/settings-nav.tsx
+++ b/src/components/settings/settings-nav.tsx
@@ -1,0 +1,52 @@
+"use client";
+
+import Link from "next/link";
+import { usePathname } from "next/navigation";
+import { KeyRound, UserCircle, type LucideIcon } from "lucide-react";
+
+import { cn } from "@/lib/utils";
+
+type SettingsNavItem = {
+  href: string;
+  label: string;
+  icon: LucideIcon;
+};
+
+const items: SettingsNavItem[] = [
+  { href: "/settings/profile", label: "Profile", icon: UserCircle },
+  { href: "/settings/api-keys", label: "API Keys", icon: KeyRound },
+];
+
+export function SettingsNav() {
+  const pathname = usePathname();
+
+  return (
+    <nav
+      aria-label="Settings sections"
+      className="flex shrink-0 flex-row gap-1 overflow-x-auto rounded-lg border bg-card p-2 md:w-60 md:flex-col"
+    >
+      {items.map(({ href, label, icon: Icon }) => {
+        const isActive =
+          pathname === href ||
+          (pathname?.startsWith(href + "/") ?? false);
+
+        return (
+          <Link
+            key={href}
+            href={href}
+            aria-current={isActive ? "page" : undefined}
+            className={cn(
+              "flex items-center gap-2 rounded-md px-3 py-2 text-sm font-medium transition-colors",
+              isActive
+                ? "bg-primary text-primary-foreground"
+                : "text-foreground hover:bg-muted",
+            )}
+          >
+            <Icon className="size-4" aria-hidden />
+            <span>{label}</span>
+          </Link>
+        );
+      })}
+    </nav>
+  );
+}

--- a/src/lib/invoice-types.ts
+++ b/src/lib/invoice-types.ts
@@ -1,0 +1,10 @@
+export type InvoiceStatus = "draft" | "pending" | "paid" | "overdue" | "cancelled";
+
+export type Invoice = {
+  referenceId: string;
+  description: string;
+  amount: string;
+  token: string;
+  status: InvoiceStatus;
+  createdAt: string;
+};


### PR DESCRIPTION
## Summary
Batches four UI tasks for the Shade merchant frontend: a reusable `InvoiceTable` primitive, the loading/disabled submit action for the Generate Invoice form, a `SettingsLayout` shell with side-nav between Profile and API Keys, and the Pay with Connected Wallet view (with mocked wallet handshake) rendered inside a tabbed payment surface. Each piece is wired into a route so reviewers can exercise the behavior — `/invoices`, `/settings/profile`, `/settings/api-keys`, `/pay`.

closes #23
closes #24
closes #38
closes #50

## Changes
- **#23 — Create "Generate Invoice" Submit Action**: New `InvoiceForm`
  (`src/components/invoice/invoice-form.tsx`). The primary `<Button type="submit">`
  shows a `Loader2` spinner with "Generating…" while submitting and is `disabled`
  whenever the form is invalid *or* `isSubmitting` is true, preventing double-clicks.
  Validation requires a non-empty description and a positive numeric amount. A
  reference ID is generated on submit, the form calls an optional `onSubmit(invoice)`
  prop (so the table can absorb the new row in `/invoices`), and the form resets
  on success. `aria-busy={isSubmitting}` is set on the button.
- **#24 — Create `InvoiceTable` Component**: New `InvoiceTable`
  (`src/components/invoice/invoice-table.tsx`). Responsive `<table>` wrapped in
  an `overflow-x-auto` container with a minimum width so it never collapses on
  narrow screens. The header row uses `sticky top-0` plus a muted background to
  stay clearly separated from rows as you scroll. Columns are exactly the ones
  the issue asks for: Reference ID (monospace), Description, Amount / Token
  (tabular nums), Status (color-coded pill), and Created (locale-formatted).
  Renders rows from an `invoices: Invoice[]` prop and shows a configurable empty
  state when the array is empty.
- **#38 — Assemble `SettingsLayout` Component**: New
  `src/app/settings/layout.tsx` plus a `SettingsNav` client component using
  `usePathname` to mark the active section with `aria-current="page"`. The
  layout renders the shared merchant header and a side-nav column on `md+`
  (collapsing to a horizontal scroll row on mobile), while the `<section>`
  beside it holds the routed page. Two child routes ship with placeholder
  copy — `/settings/profile` and `/settings/api-keys` — so the navigation has
  somewhere to navigate to, and `/settings` redirects to `/settings/profile`.
  Navigating between the two does not re-render the header or the nav.
- **#50 — Implement "Pay with Connected Wallet" View**: New
  `PayWithConnectedWalletView` (`src/components/pay/pay-with-connected-wallet-view.tsx`)
  describes the automated flow (connect → approve in wallet → invoice marks paid)
  with a numbered steps list and the primary "Connect Wallet" button. The button
  goes through `idle → connecting (Loader2 spinner) → connected (CheckCircle2)`
  using a mocked 900ms delay, per the issue's "mock the actual connection logic"
  note. It sits inside a `PayTabs` container with proper ARIA tabs semantics
  (`role=tablist/tab/tabpanel`, `aria-selected`, `aria-controls`), mounted at `/pay`,
  so the wallet view literally lives "within the active tab" as the issue requires.

Other touches:
- Added shared `Invoice` / `InvoiceStatus` types in `src/lib/invoice-types.ts`
  so the form and table agree on the row shape without copy-pasting the
  definition.

## Test plan
- Local typecheck (`npx tsc --noEmit`) — clean.
- Local Next.js production compile (`npx next build`) — compiles
  successfully. See caveat below about an unrelated lint error.
- Manually exercised the routes locally:
  - `/invoices`: submit shows the spinner + disables the button; new rows
    prepend into the table; empty state renders when the seed array is empty.
  - `/settings/profile` ↔ `/settings/api-keys`: clicking either side-nav link
    swaps only the right-hand panel and updates `aria-current`.
  - `/pay`: switching tabs swaps panels; "Connect Wallet" cycles through the
    three button states.

---
_Caveats:_
- The Next.js build's lint stage fails on a **pre-existing** unused symbol
  (`verifySignedMessage` in `src/app/sign-in/sign-in-client.tsx:42`) that exists
  on `main` and is unrelated to this PR. I deliberately did not silence or
  delete it since the issues here are scoped to invoices/settings/pay; happy to
  fix it in a separate PR if you'd like.
- The wallet handshake in `PayWithConnectedWalletView` is intentionally mocked,
  as the issue calls out. Real Stellar wallet wiring (`@creit.tech/stellar-wallets-kit`)
  will land in the wallet-integration task.

_Note: this contribution was authored with AI assistance (Claude Code)._