### PR TITLE
feat: EmptyState component + global sonner toast system

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -19,6 +19,7 @@
         "next": "15.3.1",
         "react": "^19.0.0",
         "react-dom": "^19.0.0",
+        "sonner": "^2.0.7",
         "tailwind-merge": "^3.3.1"
       },
       "devDependencies": {
@@ -334,21 +335,6 @@
         "typescript": {
           "optional": true
         }
-      }
-    },
-    "node_modules/@creit.tech/stellar-wallets-kit/node_modules/typescript": {
-      "version": "4.9.5",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.9.5.tgz",
-      "integrity": "sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==",
-      "license": "Apache-2.0",
-      "optional": true,
-      "peer": true,
-      "bin": {
-        "tsc": "bin/tsc",
-        "tsserver": "bin/tsserver"
-      },
-      "engines": {
-        "node": ">=4.2.0"
       }
     },
     "node_modules/@creit.tech/xbull-wallet-connect": {
@@ -7398,21 +7384,6 @@
         "ws": "^7.5.1"
       }
     },
-    "node_modules/@walletconnect/jsonrpc-ws-connection/node_modules/utf-8-validate": {
-      "version": "5.0.10",
-      "resolved": "https://registry.npmjs.org/utf-8-validate/-/utf-8-validate-5.0.10.tgz",
-      "integrity": "sha512-Z6czzLq4u8fPOyx7TU6X3dvUZVvoJmxSQ+IcrlmagKhilxlhZgxPK6C5Jqbkw1IDUmFTM+cz9QDnnLTwDz/2gQ==",
-      "hasInstallScript": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "node-gyp-build": "^4.3.0"
-      },
-      "engines": {
-        "node": ">=6.14.2"
-      }
-    },
     "node_modules/@walletconnect/jsonrpc-ws-connection/node_modules/ws": {
       "version": "7.5.10",
       "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.10.tgz",
@@ -11562,21 +11533,6 @@
       "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
       "license": "MIT"
     },
-    "node_modules/jayson/node_modules/utf-8-validate": {
-      "version": "5.0.10",
-      "resolved": "https://registry.npmjs.org/utf-8-validate/-/utf-8-validate-5.0.10.tgz",
-      "integrity": "sha512-Z6czzLq4u8fPOyx7TU6X3dvUZVvoJmxSQ+IcrlmagKhilxlhZgxPK6C5Jqbkw1IDUmFTM+cz9QDnnLTwDz/2gQ==",
-      "hasInstallScript": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "node-gyp-build": "^4.3.0"
-      },
-      "engines": {
-        "node": ">=6.14.2"
-      }
-    },
     "node_modules/jayson/node_modules/ws": {
       "version": "7.5.10",
       "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.10.tgz",
@@ -13923,6 +13879,16 @@
       "license": "MIT",
       "dependencies": {
         "atomic-sleep": "^1.0.0"
+      }
+    },
+    "node_modules/sonner": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/sonner/-/sonner-2.0.7.tgz",
+      "integrity": "sha512-W6ZN4p58k8aDKA4XPcx2hpIQXBRAgyiWVkYhT7CvK6D3iAu7xjvVyhQHg2/iaKJZ1XVJ4r7XuwGL+WGEK37i9w==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": "^18.0.0 || ^19.0.0 || ^19.0.0-rc",
+        "react-dom": "^18.0.0 || ^19.0.0 || ^19.0.0-rc"
       }
     },
     "node_modules/source-map-js": {

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "next": "15.3.1",
     "react": "^19.0.0",
     "react-dom": "^19.0.0",
+    "sonner": "^2.0.7",
     "tailwind-merge": "^3.3.1"
   },
   "devDependencies": {

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,5 +1,6 @@
 import type { Metadata } from "next";
 import { Geist, Geist_Mono } from "next/font/google";
+import { Toaster } from "sonner";
 import "./globals.css";
 
 const geistSans = Geist({
@@ -28,6 +29,7 @@ export default function RootLayout({
         className={`${geistSans.variable} ${geistMono.variable} antialiased`}
       >
         {children}
+        <Toaster position="top-right" richColors closeButton />
       </body>
     </html>
   );

--- a/src/components/ui/EmptyState.tsx
+++ b/src/components/ui/EmptyState.tsx
@@ -1,0 +1,51 @@
+import * as React from "react";
+
+import { cn } from "@/lib/utils";
+
+/**
+ * Generic empty-state component used wherever a list (invoices,
+ * subscriptions, etc.) has no rows to display. Centered layout with a
+ * muted-foreground description and an optional icon + action button.
+ *
+ * See ShadeProtocol/shade-frontend#57.
+ */
+export interface EmptyStateProps extends React.HTMLAttributes<HTMLDivElement> {
+  title: string;
+  description: string;
+  icon?: React.ReactNode;
+  actionButton?: React.ReactNode;
+}
+
+export function EmptyState({
+  title,
+  description,
+  icon,
+  actionButton,
+  className,
+  ...props
+}: EmptyStateProps) {
+  return (
+    <div
+      role="status"
+      className={cn(
+        "flex flex-col items-center justify-center gap-3 rounded-lg border border-dashed border-border bg-background/50 px-6 py-12 text-center",
+        className,
+      )}
+      {...props}
+    >
+      {icon ? (
+        <div
+          aria-hidden="true"
+          className="flex h-12 w-12 items-center justify-center rounded-full bg-muted text-muted-foreground [&_svg]:size-6"
+        >
+          {icon}
+        </div>
+      ) : null}
+      <h3 className="text-base font-semibold text-foreground">{title}</h3>
+      <p className="max-w-md text-sm text-muted-foreground">{description}</p>
+      {actionButton ? <div className="pt-1">{actionButton}</div> : null}
+    </div>
+  );
+}
+
+export default EmptyState;

--- a/src/lib/toast.ts
+++ b/src/lib/toast.ts
@@ -1,0 +1,34 @@
+/**
+ * Thin wrapper around `sonner` so feature code does not have to import the
+ * library directly and stays portable if the toast provider changes later.
+ *
+ * Usage:
+ *
+ *   import { notify } from "@/lib/toast";
+ *
+ *   notify.success("Link copied");
+ *   notify.error("Could not save changes");
+ *   notify.info("Heads up", "Your session expires in 5 minutes");
+ *
+ * The `<Toaster />` mount point lives in `src/app/layout.tsx`, so toasts
+ * fire from any client component without additional wiring.
+ *
+ * See ShadeProtocol/shade-frontend#59.
+ */
+import { toast } from "sonner";
+
+export const notify = {
+  success: (title: string, description?: string) =>
+    toast.success(title, description ? { description } : undefined),
+  error: (title: string, description?: string) =>
+    toast.error(title, description ? { description } : undefined),
+  info: (title: string, description?: string) =>
+    toast(title, description ? { description } : undefined),
+  warning: (title: string, description?: string) =>
+    toast.warning(title, description ? { description } : undefined),
+  /** Direct access to the underlying `sonner` toast for advanced cases
+   * (promise toasts, custom JSX, etc.). */
+  raw: toast,
+};
+
+export type Notify = typeof notify;


### PR DESCRIPTION
## Summary
One PR closing both assigned shade-frontend issues. Two small, additive
changes — a new generic empty-state primitive and the project's first
global toast layer (sonner) — plus a thin helper so feature code does not
have to import sonner directly.

closes #57
closes #59

## Per-issue detail

### closes #57 — Reusable `EmptyState` component
**File:** `src/components/ui/EmptyState.tsx` (new).

A generic, centered empty-state component used wherever a list (invoices,
subscriptions, etc.) has no data to display. Replaces ad-hoc "no data"
placeholders with a single composable primitive.

- Props: `title: string`, `description: string`,
  `icon?: ReactNode`, `actionButton?: ReactNode`, plus spread-through
  `HTMLAttributes<HTMLDivElement>` so a caller can attach `className`,
  `id`, `data-*`, etc.
- Layout: centered flex column with a dashed border and `bg-background/50`
  card, so it reads as "intentionally empty" rather than broken.
- Icon slot renders inside a 12×12 muted circle, with `aria-hidden` so the
  visible icon does not duplicate the title for screen readers; the
  outer container is `role="status"` so the empty message is announced.
- Action button slot is a generic `ReactNode` so callers can drop in a
  `<Button asChild>`, a `<Link>`, or any other element.
- Styling follows the existing shadcn pattern in `src/components/ui/button.tsx`
  (Tailwind + `cn` from `@/lib/utils`).

**Usage:**

```tsx
import { EmptyState } from "@/components/ui/EmptyState";
import { FileText } from "lucide-react";
import { Button } from "@/components/ui/button";

<EmptyState
  title="No invoices yet"
  description="When you issue your first invoice it will show up here."
  icon={<FileText />}
  actionButton={<Button>Create invoice</Button>}
/>
```

### closes #59 — Global toast notification system
**Files:** `src/app/layout.tsx`, `src/lib/toast.ts` (new), `package.json`
+ `package-lock.json`.

- Installed `sonner@^2.0.7` — modern, shadcn-recommended toast library,
  React 19 compatible. Single dependency, ~12 kB gzipped.
- Mounted `<Toaster position="top-right" richColors closeButton />` in the
  root `src/app/layout.tsx` so toasts work for every route without
  per-route plumbing.
- Added a small `notify` helper in `src/lib/toast.ts`:

  ```ts
  import { notify } from "@/lib/toast";

  notify.success("Link copied");
  notify.error("Could not save changes", "Check your network and retry.");
  notify.info("Heads up", "Your session expires in 5 minutes.");
  notify.warning("Unsaved changes");
  notify.raw.promise(savePromise, { loading: "Saving…", success: "Saved", error: "Failed" });
  ```

  The helper keeps `sonner` as an implementation detail — feature code
  never imports `sonner` directly, so swapping the underlying library
  later is a single-file change. `notify.raw` is exposed for the
  advanced cases (promise toasts, custom JSX).

## Verified locally
- `pnpm run typecheck` (`tsc --noEmit`) — clean, no new errors.
- `pnpm run lint` (`next lint`) — clean for the new files. There is one
  pre-existing lint error on `src/app/sign-in/sign-in-client.tsx:42`
  (`verifySignedMessage` defined but never used) that exists on `main`
  prior to this PR; not addressed here.
- `package-lock.json` was regenerated by `npm install sonner` — npm
  deduplicated a couple of `optional, peer` entries
  (`typescript@4.9.5`, `utf-8-validate@5.0.10`) under
  `@creit.tech/stellar-wallets-kit` and `jayson`. Those removals are
  npm's own choice, not changes to the project's direct deps.

## Honest caveats
- Did not run `npm run build` end-to-end against the dev server in this
  session (only typecheck + lint). The changes are additive and the
  imports + JSX are inspectable; no risk to existing routes.
- The pre-existing lint error in `sign-in-client.tsx` was left as-is to
  keep this PR's scope to the two assigned issues.