### PR TITLE
Add subscription card, invoice badge, details page, and API key table.

### DIFF
--- a/src/app/invoices/[id]/page.tsx
+++ b/src/app/invoices/[id]/page.tsx
@@ -1,0 +1,107 @@
+import Link from "next/link";
+
+import { InvoiceStatusBadge } from "@/components/invoice/invoice-status-badge";
+import type { InvoiceStatus } from "@/lib/invoice-types";
+
+export const metadata = {
+  title: "Invoice details | Shade",
+  description: "View invoice details.",
+};
+
+type InvoiceDetailsPageProps = {
+  params: Promise<{ id: string }>;
+};
+
+function formatDate(value: string) {
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) return value;
+  return date.toLocaleDateString(undefined, {
+    year: "numeric",
+    month: "long",
+    day: "numeric",
+  });
+}
+
+export default async function InvoiceDetailsPage({
+  params,
+}: InvoiceDetailsPageProps) {
+  const { id } = await params;
+
+  const amount = "450.00";
+  const token = "USDC";
+  const status: InvoiceStatus = "pending";
+  const createdAt = "2026-05-12T14:30:00.000Z";
+  const dueDate = "2026-06-12T14:30:00.000Z";
+  const payerName = "Acme Corp";
+  const payerEmail = "billing@acme.example";
+
+  return (
+    <main className="min-h-screen bg-background px-6 py-12 text-foreground">
+      <div className="mx-auto w-full max-w-5xl space-y-8">
+        <header className="space-y-1">
+          <Link
+            href="/invoices"
+            className="text-sm font-medium text-primary hover:underline"
+          >
+            ← Back to invoices
+          </Link>
+          <p className="text-sm font-semibold uppercase text-primary">
+            Invoice {id}
+          </p>
+        </header>
+
+        <section className="rounded-lg border bg-card p-8 shadow-sm">
+          <div className="flex flex-col gap-4 sm:flex-row sm:items-start sm:justify-between">
+            <div className="space-y-2">
+              <p className="text-sm font-medium text-muted-foreground">
+                Amount due
+              </p>
+              <p className="text-4xl font-bold tabular-nums tracking-tight">
+                {amount}{" "}
+                <span className="text-2xl font-semibold text-muted-foreground">
+                  {token}
+                </span>
+              </p>
+            </div>
+            <InvoiceStatusBadge status={status} className="text-sm px-3 py-1.5" />
+          </div>
+
+          <div className="mt-8 grid grid-cols-1 gap-6 border-t pt-8 sm:grid-cols-2">
+            <div className="space-y-1">
+              <p className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">
+                Created
+              </p>
+              <p className="text-sm font-medium">{formatDate(createdAt)}</p>
+            </div>
+            <div className="space-y-1">
+              <p className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">
+                Due date
+              </p>
+              <p className="text-sm font-medium">{formatDate(dueDate)}</p>
+            </div>
+            <div className="space-y-1">
+              <p className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">
+                Payer name
+              </p>
+              <p className="text-sm font-medium">{payerName}</p>
+            </div>
+            <div className="space-y-1">
+              <p className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">
+                Payer email
+              </p>
+              <p className="text-sm font-medium">{payerEmail}</p>
+            </div>
+            <div className="space-y-1 sm:col-span-2">
+              <p className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">
+                Description
+              </p>
+              <p className="text-sm font-medium">
+                Brand identity refresh — invoice reference {id}
+              </p>
+            </div>
+          </div>
+        </section>
+      </div>
+    </main>
+  );
+}

--- a/src/app/settings/api-keys/api-keys-client.tsx
+++ b/src/app/settings/api-keys/api-keys-client.tsx
@@ -1,0 +1,40 @@
+"use client";
+
+import { useState } from "react";
+
+import { ApiKeyTable } from "@/components/settings/api-key-table";
+import type { ApiKey } from "@/lib/api-key-types";
+
+const seedApiKeys: ApiKey[] = [
+  {
+    id: "key-001",
+    name: "Production server",
+    createdAt: "2026-03-15T10:00:00.000Z",
+    lastUsedAt: "2026-05-28T16:42:00.000Z",
+  },
+  {
+    id: "key-002",
+    name: "Staging environment",
+    createdAt: "2026-04-02T08:30:00.000Z",
+    lastUsedAt: "2026-05-20T11:15:00.000Z",
+  },
+  {
+    id: "key-003",
+    name: "Local development",
+    createdAt: "2026-05-10T14:20:00.000Z",
+    lastUsedAt: null,
+  },
+];
+
+export function ApiKeysClient() {
+  const [apiKeys, setApiKeys] = useState<ApiKey[]>(seedApiKeys);
+
+  return (
+    <ApiKeyTable
+      apiKeys={apiKeys}
+      onRevoke={(id) =>
+        setApiKeys((current) => current.filter((key) => key.id !== id))
+      }
+    />
+  );
+}

--- a/src/app/settings/api-keys/page.tsx
+++ b/src/app/settings/api-keys/page.tsx
@@ -1,3 +1,5 @@
+import { ApiKeysClient } from "./api-keys-client";
+
 export const metadata = {
   title: "API Keys · Settings | Shade",
 };
@@ -8,13 +10,11 @@ export default function ApiKeysSettingsPage() {
       <div>
         <h2 className="text-xl font-semibold">API Keys</h2>
         <p className="text-sm text-muted-foreground">
-          Programmatic access for your Shade integration.
+          Programmatic access for your Shade integration. Key values are only
+          shown once at creation and are never listed here.
         </p>
       </div>
-      <p className="text-sm text-muted-foreground">
-        Key generation will land here. You will be able to issue, rotate, and
-        revoke keys used by your server to call Shade.
-      </p>
+      <ApiKeysClient />
     </div>
   );
 }

--- a/src/components/invoice/invoice-status-badge.tsx
+++ b/src/components/invoice/invoice-status-badge.tsx
@@ -1,0 +1,38 @@
+import { cn } from "@/lib/utils";
+import type { InvoiceStatus } from "@/lib/invoice-types";
+
+const statusStyles: Record<InvoiceStatus, string> = {
+  paid: "bg-emerald-100 text-emerald-900 dark:bg-emerald-950 dark:text-emerald-300",
+  pending:
+    "bg-amber-100 text-amber-900 dark:bg-amber-950 dark:text-amber-300",
+  cancelled: "bg-red-100 text-red-900 dark:bg-red-950 dark:text-red-300",
+  draft: "bg-zinc-200 text-zinc-700 dark:bg-zinc-800 dark:text-zinc-300",
+  overdue: "bg-rose-100 text-rose-900 dark:bg-rose-950 dark:text-rose-300",
+};
+
+const statusLabels: Record<InvoiceStatus, string> = {
+  paid: "Paid",
+  pending: "Pending",
+  cancelled: "Cancelled",
+  draft: "Draft",
+  overdue: "Overdue",
+};
+
+type InvoiceStatusBadgeProps = {
+  status: InvoiceStatus;
+  className?: string;
+};
+
+export function InvoiceStatusBadge({ status, className }: InvoiceStatusBadgeProps) {
+  return (
+    <span
+      className={cn(
+        "inline-flex rounded-full px-2.5 py-1 text-xs font-medium",
+        statusStyles[status],
+        className,
+      )}
+    >
+      {statusLabels[status]}
+    </span>
+  );
+}

--- a/src/components/invoice/invoice-table.tsx
+++ b/src/components/invoice/invoice-table.tsx
@@ -1,21 +1,6 @@
+import { InvoiceStatusBadge } from "@/components/invoice/invoice-status-badge";
 import { cn } from "@/lib/utils";
-import type { Invoice, InvoiceStatus } from "@/lib/invoice-types";
-
-const statusStyles: Record<InvoiceStatus, string> = {
-  draft: "bg-muted text-muted-foreground",
-  pending: "bg-amber-100 text-amber-900",
-  paid: "bg-emerald-100 text-emerald-900",
-  overdue: "bg-rose-100 text-rose-900",
-  cancelled: "bg-zinc-200 text-zinc-700",
-};
-
-const statusLabels: Record<InvoiceStatus, string> = {
-  draft: "Draft",
-  pending: "Pending",
-  paid: "Paid",
-  overdue: "Overdue",
-  cancelled: "Cancelled",
-};
+import type { Invoice } from "@/lib/invoice-types";
 
 function formatCreatedAt(value: string) {
   const date = new Date(value);
@@ -86,14 +71,7 @@ export function InvoiceTable({ invoices, className, emptyState }: InvoiceTablePr
                   <span className="text-muted-foreground">{invoice.token}</span>
                 </td>
                 <td className="px-4 py-3">
-                  <span
-                    className={cn(
-                      "inline-flex rounded-full px-2.5 py-1 text-xs font-medium",
-                      statusStyles[invoice.status],
-                    )}
-                  >
-                    {statusLabels[invoice.status]}
-                  </span>
+                  <InvoiceStatusBadge status={invoice.status} />
                 </td>
                 <td className="px-4 py-3 text-muted-foreground">
                   {formatCreatedAt(invoice.createdAt)}

--- a/src/components/settings/api-key-table.tsx
+++ b/src/components/settings/api-key-table.tsx
@@ -1,0 +1,96 @@
+"use client";
+
+import { Trash2 } from "lucide-react";
+
+import { Button } from "@/components/ui/button";
+import { cn } from "@/lib/utils";
+import type { ApiKey } from "@/lib/api-key-types";
+
+function formatDate(value: string) {
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) return value;
+  return date.toLocaleDateString(undefined, {
+    year: "numeric",
+    month: "short",
+    day: "2-digit",
+  });
+}
+
+type ApiKeyTableProps = {
+  apiKeys: ApiKey[];
+  onRevoke?: (id: string) => void;
+  className?: string;
+  emptyState?: React.ReactNode;
+};
+
+export function ApiKeyTable({
+  apiKeys,
+  onRevoke,
+  className,
+  emptyState,
+}: ApiKeyTableProps) {
+  return (
+    <div
+      className={cn(
+        "relative w-full overflow-x-auto rounded-lg border bg-card shadow-sm",
+        className,
+      )}
+    >
+      <table className="w-full min-w-[640px] border-collapse text-left text-sm">
+        <thead className="sticky top-0 z-10 bg-muted text-muted-foreground">
+          <tr>
+            <th scope="col" className="px-4 py-3 font-semibold">
+              Name
+            </th>
+            <th scope="col" className="px-4 py-3 font-semibold">
+              Created At
+            </th>
+            <th scope="col" className="px-4 py-3 font-semibold">
+              Last Used
+            </th>
+            <th scope="col" className="px-4 py-3 font-semibold">
+              <span className="sr-only">Actions</span>
+            </th>
+          </tr>
+        </thead>
+        <tbody>
+          {apiKeys.length === 0 ? (
+            <tr>
+              <td
+                colSpan={4}
+                className="px-4 py-12 text-center text-sm text-muted-foreground"
+              >
+                {emptyState ?? "No API keys to display."}
+              </td>
+            </tr>
+          ) : (
+            apiKeys.map((apiKey) => (
+              <tr key={apiKey.id} className="border-t hover:bg-muted/40">
+                <td className="px-4 py-3 font-medium">{apiKey.name}</td>
+                <td className="px-4 py-3 text-muted-foreground">
+                  {formatDate(apiKey.createdAt)}
+                </td>
+                <td className="px-4 py-3 text-muted-foreground">
+                  {apiKey.lastUsedAt
+                    ? formatDate(apiKey.lastUsedAt)
+                    : "Never"}
+                </td>
+                <td className="px-4 py-3 text-right">
+                  <Button
+                    type="button"
+                    variant="destructive"
+                    size="sm"
+                    onClick={() => onRevoke?.(apiKey.id)}
+                  >
+                    <Trash2 className="size-3.5" />
+                    Revoke
+                  </Button>
+                </td>
+              </tr>
+            ))
+          )}
+        </tbody>
+      </table>
+    </div>
+  );
+}

--- a/src/components/subscription/subscription-plan-card.tsx
+++ b/src/components/subscription/subscription-plan-card.tsx
@@ -1,0 +1,75 @@
+import { CalendarClock, Users } from "lucide-react";
+
+import { cn } from "@/lib/utils";
+import type { SubscriptionFrequency } from "@/lib/subscription-types";
+
+const frequencyLabels: Record<SubscriptionFrequency, string> = {
+  weekly: "Weekly",
+  monthly: "Monthly",
+  quarterly: "Quarterly",
+  yearly: "Yearly",
+};
+
+type SubscriptionPlanCardProps = {
+  name: string;
+  amount: string;
+  token: string;
+  frequency: SubscriptionFrequency;
+  activeSubscribers: number;
+  className?: string;
+};
+
+export function SubscriptionPlanCard({
+  name,
+  amount,
+  token,
+  frequency,
+  activeSubscribers,
+  className,
+}: SubscriptionPlanCardProps) {
+  return (
+    <article
+      className={cn(
+        "relative overflow-hidden rounded-xl border bg-card p-6 shadow-sm transition-shadow hover:shadow-md",
+        className,
+      )}
+    >
+      <div
+        aria-hidden
+        className="absolute inset-y-0 left-0 w-1 bg-primary"
+      />
+
+      <div className="pl-3">
+        <div className="flex items-start justify-between gap-4">
+          <div className="min-w-0 space-y-1">
+            <h3 className="truncate text-lg font-semibold text-foreground">
+              {name}
+            </h3>
+            <div className="inline-flex items-center gap-1.5 text-xs font-medium text-muted-foreground">
+              <CalendarClock className="size-3.5 shrink-0" />
+              {frequencyLabels[frequency]}
+            </div>
+          </div>
+          <p className="shrink-0 text-right">
+            <span className="text-2xl font-bold tabular-nums text-foreground">
+              {amount}
+            </span>{" "}
+            <span className="text-sm font-medium text-muted-foreground">
+              {token}
+            </span>
+          </p>
+        </div>
+
+        <div className="mt-6 flex items-center gap-2 border-t pt-4 text-sm">
+          <Users className="size-4 shrink-0 text-primary" />
+          <span className="font-medium text-foreground">
+            {activeSubscribers.toLocaleString()}
+          </span>
+          <span className="text-muted-foreground">
+            active subscriber{activeSubscribers === 1 ? "" : "s"}
+          </span>
+        </div>
+      </div>
+    </article>
+  );
+}

--- a/src/lib/api-key-types.ts
+++ b/src/lib/api-key-types.ts
@@ -1,0 +1,6 @@
+export type ApiKey = {
+  id: string;
+  name: string;
+  createdAt: string;
+  lastUsedAt: string | null;
+};

--- a/src/lib/subscription-types.ts
+++ b/src/lib/subscription-types.ts
@@ -1,0 +1,14 @@
+export type SubscriptionFrequency =
+  | "weekly"
+  | "monthly"
+  | "quarterly"
+  | "yearly";
+
+export type SubscriptionPlan = {
+  id: string;
+  name: string;
+  amount: string;
+  token: string;
+  frequency: SubscriptionFrequency;
+  activeSubscribers: number;
+};


### PR DESCRIPTION
## Summary

Implements four related UI components and pages for Shade merchant tooling ([#25](https://github.com/ShadeProtocol/shade-frontend/issues/25), [#29](https://github.com/ShadeProtocol/shade-frontend/issues/29), [#33](https://github.com/ShadeProtocol/shade-frontend/issues/33), [#41](https://github.com/ShadeProtocol/shade-frontend/issues/41)):

- **`InvoiceStatusBadge`** — Reusable pill badge with semantic colors for invoice statuses (Paid, Pending, Cancelled, Draft). Adopted by `InvoiceTable` to replace inline status styling.
- **`InvoiceDetails` page** — New route at `/invoices/[id]` with a prominent amount/status header and a CSS grid layout for secondary details (dates, payer info, description). Reads the dynamic `id` param and renders a static layout.
- **`SubscriptionPlanCard`** — Card component for subscription plan templates showing plan name, amount, frequency, and active subscriber count. Visually distinct from dashboard `StatCard` while matching the existing design system.
- **`ApiKeyTable`** — Settings table listing API keys by name, created date, and last used date (key values are never displayed). Each row includes a Revoke action. Integrated into `/settings/api-keys`.

## Changes

| Area | Files |
|------|-------|
| Invoice badge | `src/components/invoice/invoice-status-badge.tsx` |
| Invoice details | `src/app/invoices/[id]/page.tsx` |
| Subscription card | `src/components/subscription/subscription-plan-card.tsx`, `src/lib/subscription-types.ts` |
| API key table | `src/components/settings/api-key-table.tsx`, `src/lib/api-key-types.ts`, `src/app/settings/api-keys/api-keys-client.tsx` |
| Integration | `src/components/invoice/invoice-table.tsx`, `src/app/settings/api-keys/page.tsx` |

## Test plan

- [ ] Visit `/invoices/INV-DEMO-001` — page renders with invoice ID in header, large amount, status badge, and grid of detail fields
- [ ] Visit `/invoices` — table status badges render with correct colors (green/amber/red/gray)
- [ ] Import and render `SubscriptionPlanCard` with sample props — card shows name, amount, frequency, and subscriber count; visually distinct from `StatCard`
- [ ] Visit `/settings/api-keys` — table shows Name, Created At, Last Used columns; no key strings visible
- [ ] Click **Revoke** on an API key row — row is removed from the table
- [ ] Run `npm run typecheck` — passes
- [ ] Toggle dark mode — badge and card colors remain readable

Closes #25 
Closes #29
Closes #33
Closes #41