### PR TITLE
feat: add subscription status toggle component

### DIFF
--- a/src/components/subscription/subscription-plan-card.tsx
+++ b/src/components/subscription/subscription-plan-card.tsx
@@ -1,6 +1,10 @@
+"use client";
+
+import { useState } from "react";
 import { CalendarClock, Users } from "lucide-react";
 
 import { cn } from "@/lib/utils";
+import { Switch } from "@/components/ui/switch";
 import type { SubscriptionFrequency } from "@/lib/subscription-types";
 
 const frequencyLabels: Record<SubscriptionFrequency, string> = {
@@ -16,6 +20,7 @@ type SubscriptionPlanCardProps = {
   token: string;
   frequency: SubscriptionFrequency;
   activeSubscribers: number;
+  defaultAcceptingNewSubscribers?: boolean;
   className?: string;
 };
 
@@ -25,8 +30,13 @@ export function SubscriptionPlanCard({
   token,
   frequency,
   activeSubscribers,
+  defaultAcceptingNewSubscribers = true,
   className,
 }: SubscriptionPlanCardProps) {
+  const [acceptingNewSubscribers, setAcceptingNewSubscribers] = useState(
+    defaultAcceptingNewSubscribers,
+  );
+
   return (
     <article
       className={cn(
@@ -60,14 +70,26 @@ export function SubscriptionPlanCard({
           </p>
         </div>
 
-        <div className="mt-6 flex items-center gap-2 border-t pt-4 text-sm">
-          <Users className="size-4 shrink-0 text-primary" />
-          <span className="font-medium text-foreground">
-            {activeSubscribers.toLocaleString()}
-          </span>
-          <span className="text-muted-foreground">
-            active subscriber{activeSubscribers === 1 ? "" : "s"}
-          </span>
+        <div className="mt-6 border-t pt-4">
+          <div className="flex items-center gap-2 text-sm">
+            <Users className="size-4 shrink-0 text-primary" />
+            <span className="font-medium text-foreground">
+              {activeSubscribers.toLocaleString()}
+            </span>
+            <span className="text-muted-foreground">
+              active subscriber{activeSubscribers === 1 ? "" : "s"}
+            </span>
+          </div>
+
+          <div className="mt-3 flex items-center justify-between">
+            <span className="text-sm text-muted-foreground">
+              Accepting New Subscribers
+            </span>
+            <Switch
+              checked={acceptingNewSubscribers}
+              onCheckedChange={setAcceptingNewSubscribers}
+            />
+          </div>
         </div>
       </div>
     </article>

--- a/src/components/ui/switch.tsx
+++ b/src/components/ui/switch.tsx
@@ -1,0 +1,49 @@
+"use client";
+
+import * as React from "react";
+
+import { cn } from "@/lib/utils";
+
+type SwitchProps = {
+  checked: boolean;
+  onCheckedChange: (checked: boolean) => void;
+  disabled?: boolean;
+  className?: string;
+  id?: string;
+  "aria-label"?: string;
+};
+
+function Switch({
+  checked,
+  onCheckedChange,
+  disabled = false,
+  className,
+  id,
+  "aria-label": ariaLabel,
+}: SwitchProps) {
+  return (
+    <button
+      type="button"
+      role="switch"
+      aria-checked={checked}
+      aria-label={ariaLabel}
+      id={id}
+      disabled={disabled}
+      onClick={() => onCheckedChange(!checked)}
+      className={cn(
+        "peer inline-flex h-5 w-9 shrink-0 cursor-pointer items-center rounded-full border-2 border-transparent transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background disabled:cursor-not-allowed disabled:opacity-50",
+        checked ? "bg-primary" : "bg-input",
+        className,
+      )}
+    >
+      <span
+        className={cn(
+          "pointer-events-none block size-4 rounded-full bg-background shadow-lg ring-0 transition-transform",
+          checked ? "translate-x-4" : "translate-x-0",
+        )}
+      />
+    </button>
+  );
+}
+
+export { Switch };


### PR DESCRIPTION
Closes #37 

Changes made:
- src/components/ui/switch.tsx (new): Reusable accessible toggle switch using role="switch" + aria-checked. Follows shadcn/ui conventions: accepts checked, onCheckedChange, disabled, className, id, aria-label. Styled with bg-primary when on, bg-input when off, with the knob animating via translate-x.
- src/components/subscription/subscription-plan-card.tsx (updated) — Added:
  - "use client" directive (needed for useState)
  - defaultAcceptingNewSubscribers prop (defaults to true)
  - Local acceptingNewSubscribers state managed by useState
  - "Accepting New Subscribers" label with the Switch toggle in the card's footer area, below the active subscribers count

How it works:

The SubscriptionPlanCard now renders a toggle labeled "Accepting New Subscribers" that switches between true/false locally via useState. The Switch component is decoupled and reusable anywhere in the app.