### PR TITLE
feat: add subscriptions list view

### DIFF
--- a/src/app/subscriptions/page.tsx
+++ b/src/app/subscriptions/page.tsx
@@ -1,0 +1,88 @@
+import { Plus } from "lucide-react";
+
+import { Sidebar } from "@/components/Sidebar";
+import { Topbar } from "@/components/Topbar";
+import { SubscriptionPlanCard } from "@/components/subscription/subscription-plan-card";
+import { Button } from "@/components/ui/button";
+import type { SubscriptionPlan } from "@/lib/subscription-types";
+
+const seedPlans: SubscriptionPlan[] = [
+  {
+    id: "plan-starter",
+    name: "Starter",
+    amount: "9.99",
+    token: "USDC",
+    frequency: "monthly",
+    activeSubscribers: 42,
+  },
+  {
+    id: "plan-pro",
+    name: "Pro",
+    amount: "49.00",
+    token: "USDC",
+    frequency: "monthly",
+    activeSubscribers: 128,
+  },
+  {
+    id: "plan-enterprise",
+    name: "Enterprise",
+    amount: "499.00",
+    token: "XLM",
+    frequency: "yearly",
+    activeSubscribers: 7,
+  },
+  {
+    id: "plan-weekly",
+    name: "Weekly digest",
+    amount: "5.00",
+    token: "USDC",
+    frequency: "weekly",
+    activeSubscribers: 19,
+  },
+];
+
+export const metadata = {
+  title: "Subscriptions | Shade",
+  description: "Manage your recurring subscription plans.",
+};
+
+export default function SubscriptionsPage() {
+  return (
+    <div className="min-h-screen bg-background">
+      <Sidebar />
+      <Topbar />
+
+      <div className="ml-60 pt-16">
+        <main className="min-h-[calc(100vh-4rem)] overflow-y-auto p-6">
+          <div className="mb-6 flex flex-col gap-4 sm:flex-row sm:items-start sm:justify-between">
+            <div>
+              <h1 className="text-2xl font-bold text-foreground">
+                Subscriptions
+              </h1>
+              <p className="mt-1 text-sm text-muted-foreground">
+                Create and manage recurring payment plans for your customers.
+              </p>
+            </div>
+            <Button type="button" className="shrink-0 gap-2 self-start">
+              <Plus className="size-4" />
+              Create New Plan
+            </Button>
+          </div>
+
+          <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 xl:grid-cols-3">
+            {seedPlans.map((plan) => (
+              <SubscriptionPlanCard
+                key={plan.id}
+                name={plan.name}
+                amount={plan.amount}
+                token={plan.token}
+                frequency={plan.frequency}
+                activeSubscribers={plan.activeSubscribers}
+              />
+            ))}
+          </div>
+        </main>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
Adds the merchant subscriptions list page at `/subscriptions` with a responsive grid of plan cards and a primary action to create a new plan.

## Purpose / Motivation
Merchants need a dedicated surface to view and manage recurring subscription plans. Issue #35 establishes the main subscriptions management route using the existing `SubscriptionPlanCard` component.

## Changes Made
- #35: Create Subscriptions List View
- Added `src/app/subscriptions/page.tsx` with dashboard shell (sidebar + topbar), page header, and demo seed plans.
- Renders multiple `SubscriptionPlanCard` components in a responsive CSS grid (`1` → `2` → `3` columns).
- Primary **Create New Plan** button at the top (UI placeholder; create flow not in scope for this issue).

## How to Test
1. Run `npm run dev` and open `/subscriptions`.
2. Confirm the page title, description, and **Create New Plan** button appear at the top.
3. Verify four plan cards render with name, amount/token, frequency, and subscriber counts.
4. Resize the viewport: cards should stack on narrow screens, two columns from `sm`, three columns from `xl`.
5. Run `npm run build` and `npm run typecheck` to confirm no compile errors.

## Breaking Changes
- None.

## Related Issues
Closes ShadeProtocol/shade-frontend#35

## Checklist
- [x] Code builds successfully (TypeScript passes)
- [ ] Tests added/updated
- [ ] No console errors
- [ ] Documentation updated (if needed)