### PR TITLE
fix: assemble dashboard page

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -22,6 +22,7 @@
         "next": "15.3.1",
         "react": "^19.0.0",
         "react-dom": "^19.0.0",
+        "recharts": "^3.8.1",
         "sonner": "^2.0.7",
         "tailwind-merge": "^3.3.1",
         "zod": "^3.25.76"
@@ -2971,6 +2972,42 @@
       "integrity": "sha512-HPwpGIzkl28mWyZqG52jiqDJ12waP11Pa1lGoiyUkIEuMLBP0oeK/C89esbXrxsky5we7dfd8U58nm0SgAWpVw==",
       "license": "MIT"
     },
+    "node_modules/@reduxjs/toolkit": {
+      "version": "2.12.0",
+      "resolved": "https://registry.npmjs.org/@reduxjs/toolkit/-/toolkit-2.12.0.tgz",
+      "integrity": "sha512-KiT+RzZbp6mQET+Mg+h2c97+9j1sNflUxQkIHI7Yuzf6Peu+OYpmkn6nbHWmLLWj+1ZODUJFwGZ7gx3L9R9EOw==",
+      "license": "MIT",
+      "dependencies": {
+        "@standard-schema/spec": "^1.0.0",
+        "@standard-schema/utils": "^0.3.0",
+        "immer": "^11.0.0",
+        "redux": "^5.0.1",
+        "redux-thunk": "^3.1.0",
+        "reselect": "^5.1.0"
+      },
+      "peerDependencies": {
+        "react": "^16.9.0 || ^17.0.0 || ^18 || ^19",
+        "react-redux": "^7.2.1 || ^8.1.3 || ^9.0.0"
+      },
+      "peerDependenciesMeta": {
+        "react": {
+          "optional": true
+        },
+        "react-redux": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@reduxjs/toolkit/node_modules/immer": {
+      "version": "11.1.8",
+      "resolved": "https://registry.npmjs.org/immer/-/immer-11.1.8.tgz",
+      "integrity": "sha512-/tbkHMW7y10Lx6i1crLjD4/OhNkRG+Fo7byZHtah0547nIeXYcpIXaUh0IAQY6gO5459qpGGYapcEOHtFXkIuA==",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/immer"
+      }
+    },
     "node_modules/@reown/appkit": {
       "version": "1.8.19",
       "resolved": "https://registry.npmjs.org/@reown/appkit/-/appkit-1.8.19.tgz",
@@ -4663,7 +4700,12 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
       "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
-      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@standard-schema/utils": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/utils/-/utils-0.3.0.tgz",
+      "integrity": "sha512-e7Mew686owMaPJVNNLs55PUvgz371nKgwsc4vxE49zsODpJEnxgxRo2y/OKrqueavXgZNMDVj3DdHFlaSAeU8g==",
       "license": "MIT"
     },
     "node_modules/@stellar/freighter-api": {
@@ -8106,6 +8148,69 @@
         "@types/node": "*"
       }
     },
+    "node_modules/@types/d3-array": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/@types/d3-array/-/d3-array-3.2.2.tgz",
+      "integrity": "sha512-hOLWVbm7uRza0BYXpIIW5pxfrKe0W+D5lrFiAEYR+pb6w3N2SwSMaJbXdUfSEv+dT4MfHBLtn5js0LAWaO6otw==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-color": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/@types/d3-color/-/d3-color-3.1.3.tgz",
+      "integrity": "sha512-iO90scth9WAbmgv7ogoq57O9YpKmFBbmoEoCHDB2xMBY0+/KVrqAaCDyCE16dUspeOvIxFFRI+0sEtqDqy2b4A==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-ease": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@types/d3-ease/-/d3-ease-3.0.2.tgz",
+      "integrity": "sha512-NcV1JjO5oDzoK26oMzbILE6HW7uVXOHLQvHshBUW4UMdZGfiY6v5BeQwh9a9tCzv+CeefZQHJt5SRgK154RtiA==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-interpolate": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@types/d3-interpolate/-/d3-interpolate-3.0.4.tgz",
+      "integrity": "sha512-mgLPETlrpVV1YRJIglr4Ez47g7Yxjl1lj7YKsiMCb27VJH9W8NVM6Bb9d8kkpG/uAQS5AmbA48q2IAolKKo1MA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-color": "*"
+      }
+    },
+    "node_modules/@types/d3-path": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/@types/d3-path/-/d3-path-3.1.1.tgz",
+      "integrity": "sha512-VMZBYyQvbGmWyWVea0EHs/BwLgxc+MKi1zLDCONksozI4YJMcTt8ZEuIR4Sb1MMTE8MMW49v0IwI5+b7RmfWlg==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-scale": {
+      "version": "4.0.9",
+      "resolved": "https://registry.npmjs.org/@types/d3-scale/-/d3-scale-4.0.9.tgz",
+      "integrity": "sha512-dLmtwB8zkAeO/juAMfnV+sItKjlsw2lKdZVVy6LRr0cBmegxSABiLEpGVmSJJ8O08i4+sGR6qQtb6WtuwJdvVw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-time": "*"
+      }
+    },
+    "node_modules/@types/d3-shape": {
+      "version": "3.1.8",
+      "resolved": "https://registry.npmjs.org/@types/d3-shape/-/d3-shape-3.1.8.tgz",
+      "integrity": "sha512-lae0iWfcDeR7qt7rA88BNiqdvPS5pFVPpo5OfjElwNaT2yyekbM0C9vK+yqBqEmHr6lDkRnYNoTBYlAgJa7a4w==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-path": "*"
+      }
+    },
+    "node_modules/@types/d3-time": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@types/d3-time/-/d3-time-3.0.4.tgz",
+      "integrity": "sha512-yuzZug1nkAAaBlBBikKZTgzCeA+k1uy4ZFwWANOfKw5z5LRhV0gNA7gNkKm7HoK+HRN0wX3EkxGk0fpbWhmB7g==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-timer": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@types/d3-timer/-/d3-timer-3.0.2.tgz",
+      "integrity": "sha512-Ps3T8E8dZDam6fUyNiMkekK3XUsaUEik+idO9/YjPtfj2qruF8tFBXS7XhtE4iIXBLxhmLjP3SXpLhVf21I9Lw==",
+      "license": "MIT"
+    },
     "node_modules/@types/deep-eql": {
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
@@ -8172,6 +8277,12 @@
       "version": "2.0.7",
       "resolved": "https://registry.npmjs.org/@types/trusted-types/-/trusted-types-2.0.7.tgz",
       "integrity": "sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==",
+      "license": "MIT"
+    },
+    "node_modules/@types/use-sync-external-store": {
+      "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/@types/use-sync-external-store/-/use-sync-external-store-0.0.6.tgz",
+      "integrity": "sha512-zFDAD+tlpf2r4asuHEj0XH6pY6i0g5NeAHPn+15wk3BV6JA69eERFXC1gyGThDkVa1zCyKr5jox1+2LbV/AMLg==",
       "license": "MIT"
     },
     "node_modules/@types/uuid": {
@@ -10580,6 +10691,20 @@
       "integrity": "sha512-571s0T7nZWK6vB67HI5dyUF7wXiNcfaPPPTl6zYCNApANjIvYJTg7hlud/+cJpdAhS7dVzqMLmfhfHR3rAcOjQ==",
       "license": "MIT"
     },
+    "node_modules/bufferutil": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/bufferutil/-/bufferutil-4.1.0.tgz",
+      "integrity": "sha512-ZMANVnAixE6AWWnPzlW2KpUrxhm9woycYvPOo67jWHyFowASTEd9s+QN1EIMsSDtwhIxN4sWE1jotpuDUIgyIw==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "node-gyp-build": "^4.3.0"
+      },
+      "engines": {
+        "node": ">=6.14.2"
+      }
+    },
     "node_modules/busboy": {
       "version": "1.6.0",
       "resolved": "https://registry.npmjs.org/busboy/-/busboy-1.6.0.tgz",
@@ -10995,6 +11120,127 @@
       "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
       "license": "MIT"
     },
+    "node_modules/d3-array": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/d3-array/-/d3-array-3.2.4.tgz",
+      "integrity": "sha512-tdQAmyA18i4J7wprpYq8ClcxZy3SC31QMeByyCFyRt7BVHdREQZ5lpzoe5mFEYZUWe+oq8HBvk9JjpibyEV4Jg==",
+      "license": "ISC",
+      "dependencies": {
+        "internmap": "1 - 2"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-color": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-color/-/d3-color-3.1.0.tgz",
+      "integrity": "sha512-zg/chbXyeBtMQ1LbD/WSoW2DpC3I0mpmPdW+ynRTj/x2DAWYrIY7qeZIHidozwV24m4iavr15lNwIwLxRmOxhA==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-ease": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-ease/-/d3-ease-3.0.1.tgz",
+      "integrity": "sha512-wR/XK3D3XcLIZwpbvQwQ5fK+8Ykds1ip7A2Txe0yxncXSdq1L9skcG7blcedkOX+ZcgxGAmLX1FrRGbADwzi0w==",
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-format": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/d3-format/-/d3-format-3.1.2.tgz",
+      "integrity": "sha512-AJDdYOdnyRDV5b6ArilzCPPwc1ejkHcoyFarqlPqT7zRYjhavcT3uSrqcMvsgh2CgoPbK3RCwyHaVyxYcP2Arg==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-interpolate": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-interpolate/-/d3-interpolate-3.0.1.tgz",
+      "integrity": "sha512-3bYs1rOD33uo8aqJfKP3JWPAibgw8Zm2+L9vBKEHJ2Rg+viTR7o5Mmv5mZcieN+FRYaAOWX5SJATX6k1PWz72g==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-color": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-path": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-path/-/d3-path-3.1.0.tgz",
+      "integrity": "sha512-p3KP5HCf/bvjBSSKuXid6Zqijx7wIfNW+J/maPs+iwR35at5JCbLUT0LzF1cnjbCHWhqzQTIN2Jpe8pRebIEFQ==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-scale": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/d3-scale/-/d3-scale-4.0.2.tgz",
+      "integrity": "sha512-GZW464g1SH7ag3Y7hXjf8RoUuAFIqklOAq3MRl4OaWabTFJY9PN/E1YklhXLh+OQ3fM9yS2nOkCoS+WLZ6kvxQ==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-array": "2.10.0 - 3",
+        "d3-format": "1 - 3",
+        "d3-interpolate": "1.2.0 - 3",
+        "d3-time": "2.1.1 - 3",
+        "d3-time-format": "2 - 4"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-shape": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/d3-shape/-/d3-shape-3.2.0.tgz",
+      "integrity": "sha512-SaLBuwGm3MOViRq2ABk3eLoxwZELpH6zhl3FbAoJ7Vm1gofKx6El1Ib5z23NUEhF9AsGl7y+dzLe5Cw2AArGTA==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-path": "^3.1.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-time": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-time/-/d3-time-3.1.0.tgz",
+      "integrity": "sha512-VqKjzBLejbSMT4IgbmVgDjpkYrNWUYJnbCGo874u7MMKIWsILRX+OpX/gTk8MqjpT1A/c6HY2dCA77ZN0lkQ2Q==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-array": "2 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-time-format": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/d3-time-format/-/d3-time-format-4.1.0.tgz",
+      "integrity": "sha512-dJxPBlzC7NugB2PDLwo9Q8JiTR3M3e4/XANkreKSUxF8vvXKqm1Yfq4Q5dl8budlunRVlUUaDUgFt7eA8D6NLg==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-time": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-timer": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-timer/-/d3-timer-3.0.1.tgz",
+      "integrity": "sha512-ndfJ/JxxMd3nw31uyKoY2naivF+r29V+Lc0svZxe1JvvIRmi8hUsrMvdOwgS1o6uBHmiz91geQ0ylPP0aj1VUA==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/damerau-levenshtein": {
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/damerau-levenshtein/-/damerau-levenshtein-1.0.8.tgz",
@@ -11145,6 +11391,12 @@
       "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.6.0.tgz",
       "integrity": "sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==",
       "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/decimal.js-light": {
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/decimal.js-light/-/decimal.js-light-2.5.1.tgz",
+      "integrity": "sha512-qIMFpTMZmny+MMIitAB6D7iVPEorVw6YQRWkvarTkT4tBeSLLiHzcwj6q0MmYSFCiVpiqPJTJEYIrpcPzVEIvg==",
       "license": "MIT"
     },
     "node_modules/deep-is": {
@@ -12862,6 +13114,16 @@
         "node": ">= 4"
       }
     },
+    "node_modules/immer": {
+      "version": "10.2.0",
+      "resolved": "https://registry.npmjs.org/immer/-/immer-10.2.0.tgz",
+      "integrity": "sha512-d/+XTN3zfODyjr89gM3mPq1WNX2B8pYsu7eORitdwyA2sBubnTl3laYlBk4sXY5FUa5qTZGBDPJICVbvqzjlbw==",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/immer"
+      }
+    },
     "node_modules/import-fresh": {
       "version": "3.3.1",
       "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.3.1.tgz",
@@ -12924,6 +13186,15 @@
       },
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/internmap": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/internmap/-/internmap-2.0.3.tgz",
+      "integrity": "sha512-5Hh7Y1wQbvY5ooGgPbDaL5iYLAPzMTUrjMulskHLH6wnv/A+1q5rgEaiuqEjB+oxGXIVZs1FF+R/KPN3ZSQYYg==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/ip-address": {
@@ -15392,8 +15663,30 @@
       "version": "16.13.1",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
       "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
-      "dev": true,
       "license": "MIT"
+    },
+    "node_modules/react-redux": {
+      "version": "9.3.0",
+      "resolved": "https://registry.npmjs.org/react-redux/-/react-redux-9.3.0.tgz",
+      "integrity": "sha512-KQopgqFo/p/fgmAs5qz6p5RWaNAzq40WAu7fJIXnQpYxFPbJYtsJPWvGeF2rOBaY/kEuV77AVsX8TsQzKm+A/g==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/use-sync-external-store": "^0.0.6",
+        "use-sync-external-store": "^1.4.0"
+      },
+      "peerDependencies": {
+        "@types/react": "^18.2.25 || ^19",
+        "react": "^18.0 || ^19",
+        "redux": "^5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "redux": {
+          "optional": true
+        }
+      }
     },
     "node_modules/react-remove-scroll": {
       "version": "2.7.2",
@@ -15500,6 +15793,36 @@
         "node": ">= 12.13.0"
       }
     },
+    "node_modules/recharts": {
+      "version": "3.8.1",
+      "resolved": "https://registry.npmjs.org/recharts/-/recharts-3.8.1.tgz",
+      "integrity": "sha512-mwzmO1s9sFL0TduUpwndxCUNoXsBw3u3E/0+A+cLcrSfQitSG62L32N69GhqUrrT5qKcAE3pCGVINC6pqkBBQg==",
+      "license": "MIT",
+      "workspaces": [
+        "www"
+      ],
+      "dependencies": {
+        "@reduxjs/toolkit": "^1.9.0 || 2.x.x",
+        "clsx": "^2.1.1",
+        "decimal.js-light": "^2.5.1",
+        "es-toolkit": "^1.39.3",
+        "eventemitter3": "^5.0.1",
+        "immer": "^10.1.1",
+        "react-redux": "8.x.x || 9.x.x",
+        "reselect": "5.1.1",
+        "tiny-invariant": "^1.3.3",
+        "use-sync-external-store": "^1.2.2",
+        "victory-vendor": "^37.0.2"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react-dom": "^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react-is": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
     "node_modules/redent": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/redent/-/redent-3.0.0.tgz",
@@ -15512,6 +15835,21 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/redux": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/redux/-/redux-5.0.1.tgz",
+      "integrity": "sha512-M9/ELqF6fy8FwmkpnF0S3YKOqMyoWJ4+CS5Efg2ct3oY9daQvd/Pc71FpGZsVsbl3Cpb+IIcjBDUnnyBdQbq4w==",
+      "license": "MIT"
+    },
+    "node_modules/redux-thunk": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/redux-thunk/-/redux-thunk-3.1.0.tgz",
+      "integrity": "sha512-NW2r5T6ksUKXCabzhL9z+h206HQw/NJkcLm1GPImRQ8IzfXwRGqjVhKJGauHirT0DAuyy6hjdnMZaRoAcy0Klw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "redux": "^5.0.0"
       }
     },
     "node_modules/reflect.getprototypeof": {
@@ -15596,6 +15934,12 @@
       "resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-2.0.0.tgz",
       "integrity": "sha512-NKN5kMDylKuldxYLSUfrbo5Tuzh4hd+2E8NPPX02mZtn1VuREQToYe/ZdlJy+J3uCpfaiGF05e7B8W0iXbQHmg==",
       "license": "ISC"
+    },
+    "node_modules/reselect": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/reselect/-/reselect-5.1.1.tgz",
+      "integrity": "sha512-K/BG6eIky/SBpzfHZv/dd+9JBFiS4SWV7FIujVyJRux6e45+73RaUHXLmIR1f7WOMaQ0U1km6qwklRQxpJJY0w==",
+      "license": "MIT"
     },
     "node_modules/resolve": {
       "version": "2.0.0-next.7",
@@ -15771,9 +16115,6 @@
       "dependencies": {
         "@types/node": "*"
       }
-    },
-    "node_modules/rpc-websockets/node_modules/bufferutil": {
-      "optional": true
     },
     "node_modules/rpc-websockets/node_modules/uuid": {
       "version": "14.0.0",
@@ -16678,6 +17019,12 @@
         "real-require": "^0.2.0"
       }
     },
+    "node_modules/tiny-invariant": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/tiny-invariant/-/tiny-invariant-1.3.3.tgz",
+      "integrity": "sha512-+FbBPE1o9QAYvviau/qC5SE3caw21q3xkvWKBtja5vgqOWIHHJ3ioaq1VPfn/Szqctz2bU/oYeKd9/z5BL+PVg==",
+      "license": "MIT"
+    },
     "node_modules/tiny-secp256k1": {
       "version": "1.1.7",
       "resolved": "https://registry.npmjs.org/tiny-secp256k1/-/tiny-secp256k1-1.1.7.tgz",
@@ -17360,6 +17707,15 @@
         }
       }
     },
+    "node_modules/use-sync-external-store": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/use-sync-external-store/-/use-sync-external-store-1.6.0.tgz",
+      "integrity": "sha512-Pp6GSwGP/NrPIrxVFAIkOQeyw8lFenOHijQWkUTrDvrF4ALqylP2C/KCkeS9dpUM3KvYRQhna5vt7IL95+ZQ9w==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
     "node_modules/utf-8-validate": {
       "version": "6.0.6",
       "resolved": "https://registry.npmjs.org/utf-8-validate/-/utf-8-validate-6.0.6.tgz",
@@ -17427,6 +17783,28 @@
       "license": "MIT",
       "dependencies": {
         "uint8array-tools": "^0.0.8"
+      }
+    },
+    "node_modules/victory-vendor": {
+      "version": "37.3.6",
+      "resolved": "https://registry.npmjs.org/victory-vendor/-/victory-vendor-37.3.6.tgz",
+      "integrity": "sha512-SbPDPdDBYp+5MJHhBCAyI7wKM3d5ivekigc2Dk2s7pgbZ9wIgIBYGVw4zGHBml/qTFbexrofXW6Gu4noGxrOwQ==",
+      "license": "MIT AND ISC",
+      "dependencies": {
+        "@types/d3-array": "^3.0.3",
+        "@types/d3-ease": "^3.0.0",
+        "@types/d3-interpolate": "^3.0.1",
+        "@types/d3-scale": "^4.0.2",
+        "@types/d3-shape": "^3.1.0",
+        "@types/d3-time": "^3.0.0",
+        "@types/d3-timer": "^3.0.0",
+        "d3-array": "^3.1.6",
+        "d3-ease": "^3.0.1",
+        "d3-interpolate": "^3.0.1",
+        "d3-scale": "^4.0.2",
+        "d3-shape": "^3.1.0",
+        "d3-time": "^3.0.0",
+        "d3-timer": "^3.0.1"
       }
     },
     "node_modules/viem": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -457,6 +457,21 @@
         "node": ">=10"
       }
     },
+    "node_modules/@creit.tech/stellar-wallets-kit/node_modules/typescript": {
+      "version": "4.9.5",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.9.5.tgz",
+      "integrity": "sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==",
+      "license": "Apache-2.0",
+      "optional": true,
+      "peer": true,
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=4.2.0"
+      }
+    },
     "node_modules/@creit.tech/xbull-wallet-connect": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/@creit.tech/xbull-wallet-connect/-/xbull-wallet-connect-0.4.0.tgz",
@@ -9244,6 +9259,21 @@
         "ws": "^7.5.1"
       }
     },
+    "node_modules/@walletconnect/jsonrpc-ws-connection/node_modules/utf-8-validate": {
+      "version": "5.0.10",
+      "resolved": "https://registry.npmjs.org/utf-8-validate/-/utf-8-validate-5.0.10.tgz",
+      "integrity": "sha512-Z6czzLq4u8fPOyx7TU6X3dvUZVvoJmxSQ+IcrlmagKhilxlhZgxPK6C5Jqbkw1IDUmFTM+cz9QDnnLTwDz/2gQ==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "node-gyp-build": "^4.3.0"
+      },
+      "engines": {
+        "node": ">=6.14.2"
+      }
+    },
     "node_modules/@walletconnect/jsonrpc-ws-connection/node_modules/ws": {
       "version": "7.5.11",
       "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.11.tgz",
@@ -13791,6 +13821,21 @@
       "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
       "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
       "license": "MIT"
+    },
+    "node_modules/jayson/node_modules/utf-8-validate": {
+      "version": "5.0.10",
+      "resolved": "https://registry.npmjs.org/utf-8-validate/-/utf-8-validate-5.0.10.tgz",
+      "integrity": "sha512-Z6czzLq4u8fPOyx7TU6X3dvUZVvoJmxSQ+IcrlmagKhilxlhZgxPK6C5Jqbkw1IDUmFTM+cz9QDnnLTwDz/2gQ==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "node-gyp-build": "^4.3.0"
+      },
+      "engines": {
+        "node": ">=6.14.2"
+      }
     },
     "node_modules/jayson/node_modules/ws": {
       "version": "7.5.11",

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "next": "15.3.1",
     "react": "^19.0.0",
     "react-dom": "^19.0.0",
+    "recharts": "^3.8.1",
     "sonner": "^2.0.7",
     "tailwind-merge": "^3.3.1",
     "zod": "^3.25.76"

--- a/src/app/(dashboard)/dashboard/layout.tsx
+++ b/src/app/(dashboard)/dashboard/layout.tsx
@@ -1,9 +1,7 @@
-import { DashboardShell } from "@/components/layout/DashboardShell";
-
 export default function DashboardLayout({
   children,
 }: {
   children: React.ReactNode;
 }) {
-  return <DashboardShell>{children}</DashboardShell>;
+  return children;
 }

--- a/src/app/(dashboard)/dashboard/page.tsx
+++ b/src/app/(dashboard)/dashboard/page.tsx
@@ -1,13 +1,49 @@
 import { DollarSign, FileText, TrendingUp, Users } from "lucide-react";
 
+import RecentActivity from "@/components/RecentActivity";
+import RevenueChart from "@/components/RevenueChart";
 import { ApiKeyManagement } from "@/components/dashboard/api-key-management";
 import { StatCard } from "@/components/StatCard";
+import type { ActivityEvent } from "@/lib/activity";
 import { DashboardActions } from "./dashboard-actions";
 
 export const metadata = {
   title: "Dashboard | Shade",
   description: "Shade merchant dashboard.",
 };
+
+const RECENT_ACTIVITY_EVENTS: ActivityEvent[] = [
+  {
+    id: "evt_1",
+    type: "invoice_paid",
+    description: "Invoice INV-1042 was paid",
+    amount: 1840,
+    currency: "USD",
+    timestamp: "2026-06-23T10:15:00Z",
+  },
+  {
+    id: "evt_2",
+    type: "invoice_created",
+    description: "New invoice INV-1043 was created",
+    amount: 620,
+    currency: "USD",
+    timestamp: "2026-06-23T08:40:00Z",
+  },
+  {
+    id: "evt_3",
+    type: "customer_added",
+    description: "Acme Labs was added as a customer",
+    timestamp: "2026-06-22T16:20:00Z",
+  },
+  {
+    id: "evt_4",
+    type: "payout_sent",
+    description: "Weekly payout sent to connected wallet",
+    amount: 3120,
+    currency: "USD",
+    timestamp: "2026-06-21T12:00:00Z",
+  },
+];
 
 export default function DashboardPage() {
   return (
@@ -44,6 +80,13 @@ export default function DashboardPage() {
           icon={<TrendingUp className="size-4" />}
           trend={5.4}
         />
+      </div>
+
+      <div className="grid grid-cols-1 gap-4 lg:grid-cols-3">
+        <div className="lg:col-span-2">
+          <RevenueChart />
+        </div>
+        <RecentActivity events={RECENT_ACTIVITY_EVENTS} className="h-full" />
       </div>
 
       <DashboardActions />

--- a/src/app/(dashboard)/invoice-tools/invoice-tools-client.tsx
+++ b/src/app/(dashboard)/invoice-tools/invoice-tools-client.tsx
@@ -36,7 +36,9 @@ export function InvoiceToolsClient() {
   return (
     <div className="grid grid-cols-1 gap-8 lg:grid-cols-2">
       <section className="space-y-3">
-        <h2 className="text-lg font-semibold">Create invoice (with validation)</h2>
+        <h2 className="text-lg font-semibold">
+          Create invoice (with validation)
+        </h2>
         <InvoiceCreateForm
           onDraft={(draft) => {
             console.log("Draft saved:", draft);

--- a/src/app/(dashboard)/invoices/invoices-client.tsx
+++ b/src/app/(dashboard)/invoices/invoices-client.tsx
@@ -47,10 +47,14 @@ export function InvoicesClient() {
     })
     .sort((a, b) => {
       if (sortBy === "newest") {
-        return new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime();
+        return (
+          new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime()
+        );
       }
       if (sortBy === "oldest") {
-        return new Date(a.createdAt).getTime() - new Date(b.createdAt).getTime();
+        return (
+          new Date(a.createdAt).getTime() - new Date(b.createdAt).getTime()
+        );
       }
       if (sortBy === "amount-high") {
         return Number(b.amount) - Number(a.amount);
@@ -80,9 +84,7 @@ export function InvoicesClient() {
   return (
     <div className="flex flex-col gap-8">
       <InvoiceForm
-        onSubmit={(invoice) =>
-          setInvoices((current) => [invoice, ...current])
-        }
+        onSubmit={(invoice) => setInvoices((current) => [invoice, ...current])}
       />
       <section className="space-y-4">
         <h2 className="text-lg font-semibold text-foreground">Your invoices</h2>
@@ -109,4 +111,3 @@ export function InvoicesClient() {
     </div>
   );
 }
-

--- a/src/app/(dashboard)/settings/api-keys/page.tsx
+++ b/src/app/(dashboard)/settings/api-keys/page.tsx
@@ -18,4 +18,3 @@ export default function ApiKeysSettingsPage() {
     </div>
   );
 }
-

--- a/src/app/pay/page.tsx
+++ b/src/app/pay/page.tsx
@@ -10,9 +10,7 @@ export default function PayPage() {
     <main className="min-h-screen bg-background px-6 py-12 text-foreground">
       <div className="mx-auto w-full max-w-3xl space-y-6">
         <header className="space-y-1">
-          <p className="text-sm font-semibold uppercase text-primary">
-            Shade
-          </p>
+          <p className="text-sm font-semibold uppercase text-primary">Shade</p>
           <h1 className="text-3xl font-bold">Pay invoice</h1>
           <p className="text-sm text-muted-foreground">
             Choose how you want to settle this invoice.

--- a/src/app/payment/[id]/page.tsx
+++ b/src/app/payment/[id]/page.tsx
@@ -80,7 +80,9 @@ export default function PublicPaymentPage() {
             Loading invoice details...
           </p>
         </div>
-      ) : !invoice || invoice.status === "invalid" || invoice.status === "expired" ? (
+      ) : !invoice ||
+        invoice.status === "invalid" ||
+        invoice.status === "expired" ? (
         <InvalidInvoiceState
           message={
             invoice?.status === "expired"

--- a/src/app/sign-in/sign-in-client.tsx
+++ b/src/app/sign-in/sign-in-client.tsx
@@ -47,7 +47,7 @@ function createChallenge(address: string) {
 //   const keypair = Keypair.fromPublicKey(signerAddress);
 //   const messageBytes = Buffer.from(challenge, "utf8");
 //   const signatureBytes = Buffer.from(signedMessage, "base64");
-// 
+//
 //   return keypair.verify(messageBytes, signatureBytes);
 // }
 

--- a/src/components/MobileNav.tsx
+++ b/src/components/MobileNav.tsx
@@ -100,7 +100,8 @@ export function MobileNav() {
           <nav className="flex-1 overflow-y-auto px-3 py-4">
             <ul className="flex flex-col gap-0.5">
               {navItems.map(({ href, label, icon: Icon }) => {
-                const active = pathname === href || pathname.startsWith(href + "/");
+                const active =
+                  pathname === href || pathname.startsWith(href + "/");
                 return (
                   <li key={href}>
                     <Link
@@ -133,4 +134,3 @@ export function MobileNav() {
     </div>
   );
 }
-

--- a/src/components/RevenueChart.tsx
+++ b/src/components/RevenueChart.tsx
@@ -59,9 +59,14 @@ interface RevenueChartProps {
 export default function RevenueChart({ data = MOCK_DATA }: RevenueChartProps) {
   return (
     <div className="rounded-lg border bg-card p-6 shadow-sm">
-      <h2 className="mb-4 text-lg font-bold text-card-foreground">Revenue Over Time</h2>
+      <h2 className="mb-4 text-lg font-bold text-card-foreground">
+        Revenue Over Time
+      </h2>
       <ResponsiveContainer width="100%" height={260}>
-        <AreaChart data={data} margin={{ top: 4, right: 8, left: 0, bottom: 0 }}>
+        <AreaChart
+          data={data}
+          margin={{ top: 4, right: 8, left: 0, bottom: 0 }}
+        >
           <defs>
             <linearGradient id="revenueGradient" x1="0" y1="0" x2="0" y2="1">
               <stop offset="5%" stopColor="var(--primary)" stopOpacity={0.25} />
@@ -81,7 +86,15 @@ export default function RevenueChart({ data = MOCK_DATA }: RevenueChartProps) {
             tickLine={false}
             width={48}
           />
-          <Tooltip content={(props) => <CustomTooltip active={props.active} payload={props.payload} label={String(props.label ?? "")} />} />
+          <Tooltip
+            content={(props) => (
+              <CustomTooltip
+                active={props.active}
+                payload={props.payload}
+                label={String(props.label ?? "")}
+              />
+            )}
+          />
           <Area
             type="monotone"
             dataKey="amount"

--- a/src/components/RevenueChart.tsx
+++ b/src/components/RevenueChart.tsx
@@ -16,21 +16,29 @@ export interface RevenueDataPoint {
 }
 
 interface TooltipPayload {
-  value?: number;
+  value?: number | string | readonly (number | string)[];
 }
 
 interface CustomTooltipProps {
   active?: boolean;
-  payload?: TooltipPayload[];
+  payload?: readonly TooltipPayload[];
   label?: string;
 }
 
 function CustomTooltip({ active, payload, label }: CustomTooltipProps) {
   if (!active || !payload?.length) return null;
+
+  const value = payload[0].value;
+  const formattedValue = Array.isArray(value)
+    ? value.join(", ")
+    : typeof value === "number"
+      ? value.toLocaleString()
+      : value;
+
   return (
     <div className="rounded-md border bg-card px-3 py-2 text-sm shadow-md">
       <p className="font-medium text-card-foreground">{label}</p>
-      <p className="text-primary">{payload[0].value?.toLocaleString()} XLM</p>
+      <p className="text-primary">{formattedValue} XLM</p>
     </div>
   );
 }

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -29,8 +29,7 @@ export function Sidebar() {
       <nav className="flex-1 overflow-y-auto px-3 py-4">
         <ul className="flex flex-col gap-0.5">
           {navItems.map(({ href, label, icon: Icon }) => {
-            const active =
-              pathname === href || pathname.startsWith(href + "/");
+            const active = pathname === href || pathname.startsWith(href + "/");
             return (
               <li key={href}>
                 <Link

--- a/src/components/ThemeProvider.tsx
+++ b/src/components/ThemeProvider.tsx
@@ -17,7 +17,9 @@ export function ThemeProvider({ children }: { children: React.ReactNode }) {
 
   useEffect(() => {
     const stored = localStorage.getItem("shade:theme");
-    const systemDark = window.matchMedia("(prefers-color-scheme: dark)").matches;
+    const systemDark = window.matchMedia(
+      "(prefers-color-scheme: dark)",
+    ).matches;
     const dark = stored === "dark" || (stored !== "light" && systemDark);
     setIsDark(dark);
     document.documentElement.classList.toggle("dark", dark);

--- a/src/components/avatar/avatar-upload.tsx
+++ b/src/components/avatar/avatar-upload.tsx
@@ -1,12 +1,6 @@
 "use client";
 
-import {
-  ChangeEvent,
-  KeyboardEvent,
-  useEffect,
-  useRef,
-  useState,
-} from "react";
+import { ChangeEvent, KeyboardEvent, useEffect, useRef, useState } from "react";
 import { ImagePlus } from "lucide-react";
 
 import { cn } from "@/lib/utils";

--- a/src/components/billing/billing-plan-form.test.tsx
+++ b/src/components/billing/billing-plan-form.test.tsx
@@ -46,7 +46,9 @@ describe("BillingPlanForm", () => {
 
     await user.click(screen.getByRole("button", { name: /create plan/i }));
 
-    expect(await screen.findByText(/plan name is required/i)).toBeInTheDocument();
+    expect(
+      await screen.findByText(/plan name is required/i),
+    ).toBeInTheDocument();
     expect(screen.getByText(/description is required/i)).toBeInTheDocument();
     expect(screen.getByText(/amount must be/i)).toBeInTheDocument();
     expect(handleSubmit).not.toHaveBeenCalled();
@@ -61,10 +63,7 @@ describe("BillingPlanForm", () => {
     await user.type(screen.getByLabelText(/plan name/i), "Starter");
     await user.type(screen.getByLabelText(/description/i), "Entry tier");
     await user.type(screen.getByLabelText(/^amount$/i), "0");
-    await user.type(
-      screen.getByLabelText(/customer email/i),
-      "not-an-email",
-    );
+    await user.type(screen.getByLabelText(/customer email/i), "not-an-email");
 
     await user.click(screen.getByRole("button", { name: /create plan/i }));
 
@@ -86,6 +85,8 @@ describe("BillingPlanForm", () => {
     ).toBeInTheDocument();
 
     await user.type(screen.getByLabelText(/plan name/i), "Pro");
-    expect(screen.queryByText(/plan name is required/i)).not.toBeInTheDocument();
+    expect(
+      screen.queryByText(/plan name is required/i),
+    ).not.toBeInTheDocument();
   });
 });

--- a/src/components/billing/billing-plan-form.tsx
+++ b/src/components/billing/billing-plan-form.tsx
@@ -77,8 +77,8 @@ export function BillingPlanForm({ onSubmit }: BillingPlanFormProps) {
       <div className="space-y-1">
         <h2 className="text-xl font-semibold">Create billing plan</h2>
         <p className="text-sm text-muted-foreground">
-          Define a recurring charge. Validate every field before activating
-          the plan.
+          Define a recurring charge. Validate every field before activating the
+          plan.
         </p>
       </div>
 
@@ -145,9 +145,7 @@ export function BillingPlanForm({ onSubmit }: BillingPlanFormProps) {
           id="plan-interval"
           required
           aria-invalid={Boolean(errors.interval)}
-          aria-describedby={
-            errors.interval ? "plan-interval-error" : undefined
-          }
+          aria-describedby={errors.interval ? "plan-interval-error" : undefined}
           value={draft.interval}
           onChange={(event) => updateField("interval", event.target.value)}
           disabled={isSubmitting}
@@ -175,9 +173,7 @@ export function BillingPlanForm({ onSubmit }: BillingPlanFormProps) {
             errors.customerEmail ? "plan-customer-email-error" : undefined
           }
           value={draft.customerEmail}
-          onChange={(event) =>
-            updateField("customerEmail", event.target.value)
-          }
+          onChange={(event) => updateField("customerEmail", event.target.value)}
           disabled={isSubmitting}
           className={inputClass(Boolean(errors.customerEmail))}
           placeholder="customer@example.com"

--- a/src/components/invoice/invoice-controls.tsx
+++ b/src/components/invoice/invoice-controls.tsx
@@ -48,7 +48,10 @@ export function InvoiceControls({
       <div className="flex flex-wrap items-center gap-3">
         {/* Status Dropdown */}
         <div className="flex items-center gap-2">
-          <label htmlFor="status-filter" className="text-xs font-semibold text-muted-foreground uppercase tracking-wide hidden md:inline">
+          <label
+            htmlFor="status-filter"
+            className="text-xs font-semibold text-muted-foreground uppercase tracking-wide hidden md:inline"
+          >
             Status:
           </label>
           <select
@@ -67,7 +70,10 @@ export function InvoiceControls({
 
         {/* Sort Dropdown */}
         <div className="flex items-center gap-2">
-          <label htmlFor="sort-by" className="text-xs font-semibold text-muted-foreground uppercase tracking-wide hidden md:inline">
+          <label
+            htmlFor="sort-by"
+            className="text-xs font-semibold text-muted-foreground uppercase tracking-wide hidden md:inline"
+          >
             Sort by:
           </label>
           <select

--- a/src/components/invoice/invoice-create-form.tsx
+++ b/src/components/invoice/invoice-create-form.tsx
@@ -33,7 +33,10 @@ export type InvoiceCreateFormProps = {
   onDraft?: (draft: typeof initialDraft) => void;
 };
 
-export function InvoiceCreateForm({ onSubmit, onDraft }: InvoiceCreateFormProps) {
+export function InvoiceCreateForm({
+  onSubmit,
+  onDraft,
+}: InvoiceCreateFormProps) {
   const [draft, setDraft] = useState(initialDraft);
   const [errors, setErrors] = useState<FieldErrors>({});
   const [isSubmitting, setIsSubmitting] = useState(false);
@@ -128,9 +131,7 @@ export function InvoiceCreateForm({ onSubmit, onDraft }: InvoiceCreateFormProps)
           step="0.01"
           required
           aria-invalid={Boolean(errors.amount)}
-          aria-describedby={
-            errors.amount ? "invoice-amount-error" : undefined
-          }
+          aria-describedby={errors.amount ? "invoice-amount-error" : undefined}
           value={draft.amount}
           onChange={(event) => updateField("amount", event.target.value)}
           disabled={isSubmitting}
@@ -153,9 +154,7 @@ export function InvoiceCreateForm({ onSubmit, onDraft }: InvoiceCreateFormProps)
             errors.customerEmail ? "invoice-customer-email-error" : undefined
           }
           value={draft.customerEmail}
-          onChange={(event) =>
-            updateField("customerEmail", event.target.value)
-          }
+          onChange={(event) => updateField("customerEmail", event.target.value)}
           disabled={isSubmitting}
           className={inputClass(Boolean(errors.customerEmail))}
           placeholder="customer@example.com"
@@ -198,21 +197,21 @@ export function InvoiceCreateForm({ onSubmit, onDraft }: InvoiceCreateFormProps)
         )}
       </Button>
       <Button
-          type="button"
-          variant="secondary"
-          disabled={isSubmitting || isDrafting}
-          onClick={handleSaveDraft}
-          className="self-start"
-        >
-          {isDrafting ? (
-            <>
-              <Loader2 className="animate-spin" aria-hidden />
-              <span>Saving draft…</span>
-            </>
-          ) : (
-            "Save as draft"
-          )}
-        </Button>
+        type="button"
+        variant="secondary"
+        disabled={isSubmitting || isDrafting}
+        onClick={handleSaveDraft}
+        className="self-start"
+      >
+        {isDrafting ? (
+          <>
+            <Loader2 className="animate-spin" aria-hidden />
+            <span>Saving draft…</span>
+          </>
+        ) : (
+          "Save as draft"
+        )}
+      </Button>
     </form>
   );
 }

--- a/src/components/invoice/invoice-form.tsx
+++ b/src/components/invoice/invoice-form.tsx
@@ -104,7 +104,9 @@ export function InvoiceForm({ onSubmit }: InvoiceFormProps) {
       noValidate
     >
       <div className="space-y-1">
-        <h2 className="text-xl font-bold tracking-tight text-foreground">Generate invoice</h2>
+        <h2 className="text-xl font-bold tracking-tight text-foreground">
+          Generate invoice
+        </h2>
         <p className="text-sm text-muted-foreground">
           Create a payable invoice your customer can settle on Stellar.
         </p>
@@ -116,7 +118,9 @@ export function InvoiceForm({ onSubmit }: InvoiceFormProps) {
           <h3 className="text-sm font-semibold tracking-wide text-foreground uppercase">
             Basic Details
           </h3>
-          <span className="text-[11px] font-medium text-indigo-500 bg-indigo-500/10 px-2 py-0.5 rounded-full">Required</span>
+          <span className="text-[11px] font-medium text-indigo-500 bg-indigo-500/10 px-2 py-0.5 rounded-full">
+            Required
+          </span>
         </div>
 
         <div className="grid grid-cols-1 gap-4 sm:grid-cols-2">
@@ -183,11 +187,15 @@ export function InvoiceForm({ onSubmit }: InvoiceFormProps) {
         {showAdvanced && (
           <div className="grid grid-cols-1 gap-4 pt-2 border-t border-border/20 animate-in fade-in-50 slide-in-from-top-2 duration-200">
             <label className="flex flex-col gap-1.5 text-sm">
-              <span className="font-medium text-foreground">Payer Email (optional)</span>
+              <span className="font-medium text-foreground">
+                Payer Email (optional)
+              </span>
               <input
                 type="email"
                 value={draft.payerEmail}
-                onChange={(event) => updateField("payerEmail", event.target.value)}
+                onChange={(event) =>
+                  updateField("payerEmail", event.target.value)
+                }
                 className={`rounded-md border bg-background px-3 py-2 text-sm shadow-sm transition-all focus:outline-none focus:ring-2 focus:ring-indigo-500 disabled:opacity-60 text-foreground ${
                   draft.payerEmail && !isEmailValid(draft.payerEmail)
                     ? "border-destructive focus:ring-destructive"
@@ -197,16 +205,22 @@ export function InvoiceForm({ onSubmit }: InvoiceFormProps) {
                 disabled={isSubmitting}
               />
               {draft.payerEmail && !isEmailValid(draft.payerEmail) && (
-                <span className="text-xs text-destructive">Please enter a valid email address</span>
+                <span className="text-xs text-destructive">
+                  Please enter a valid email address
+                </span>
               )}
             </label>
 
             <label className="flex flex-col gap-1.5 text-sm">
-              <span className="font-medium text-foreground">Expiration Date (optional)</span>
+              <span className="font-medium text-foreground">
+                Expiration Date (optional)
+              </span>
               <input
                 type="date"
                 value={draft.expiration}
-                onChange={(event) => updateField("expiration", event.target.value)}
+                onChange={(event) =>
+                  updateField("expiration", event.target.value)
+                }
                 className="rounded-md border border-input bg-background px-3 py-2 text-sm shadow-sm transition-all focus:outline-none focus:ring-2 focus:ring-ring focus:ring-indigo-500 disabled:opacity-60 text-foreground"
                 disabled={isSubmitting}
               />
@@ -227,7 +241,10 @@ export function InvoiceForm({ onSubmit }: InvoiceFormProps) {
           className="rounded-md border border-emerald-300 bg-emerald-50 dark:bg-emerald-950/20 dark:border-emerald-900/50 px-3 py-2 text-sm text-emerald-900 dark:text-emerald-300 space-y-1"
         >
           <p>
-            Invoice <span className="font-mono font-semibold">{createdInvoice.referenceId}</span>{" "}
+            Invoice{" "}
+            <span className="font-mono font-semibold">
+              {createdInvoice.referenceId}
+            </span>{" "}
             generated successfully.
           </p>
           {createdInvoice.payerEmail && (
@@ -237,7 +254,8 @@ export function InvoiceForm({ onSubmit }: InvoiceFormProps) {
           )}
           {createdInvoice.expiration && (
             <p className="text-xs text-emerald-700 dark:text-emerald-400">
-              Expires: {new Date(createdInvoice.expiration).toLocaleDateString()}
+              Expires:{" "}
+              {new Date(createdInvoice.expiration).toLocaleDateString()}
             </p>
           )}
         </div>
@@ -261,4 +279,3 @@ export function InvoiceForm({ onSubmit }: InvoiceFormProps) {
     </form>
   );
 }
-

--- a/src/components/invoice/invoice-pagination.tsx
+++ b/src/components/invoice/invoice-pagination.tsx
@@ -26,10 +26,7 @@ export function InvoicePagination({
 
   return (
     <div
-      className={cn(
-        "flex items-center justify-between gap-4 px-1",
-        className,
-      )}
+      className={cn("flex items-center justify-between gap-4 px-1", className)}
     >
       <p className="text-sm text-muted-foreground" aria-live="polite">
         Page {page} of {pageCount}

--- a/src/components/invoice/invoice-status-badge.tsx
+++ b/src/components/invoice/invoice-status-badge.tsx
@@ -3,8 +3,7 @@ import type { InvoiceStatus } from "@/lib/invoice-types";
 
 const statusStyles: Record<InvoiceStatus, string> = {
   paid: "bg-emerald-100 text-emerald-900 dark:bg-emerald-950 dark:text-emerald-300",
-  pending:
-    "bg-amber-100 text-amber-900 dark:bg-amber-950 dark:text-amber-300",
+  pending: "bg-amber-100 text-amber-900 dark:bg-amber-950 dark:text-amber-300",
   cancelled: "bg-red-100 text-red-900 dark:bg-red-950 dark:text-red-300",
   draft: "bg-zinc-200 text-zinc-700 dark:bg-zinc-800 dark:text-zinc-300",
   overdue: "bg-rose-100 text-rose-900 dark:bg-rose-950 dark:text-rose-300",
@@ -23,7 +22,10 @@ type InvoiceStatusBadgeProps = {
   className?: string;
 };
 
-export function InvoiceStatusBadge({ status, className }: InvoiceStatusBadgeProps) {
+export function InvoiceStatusBadge({
+  status,
+  className,
+}: InvoiceStatusBadgeProps) {
   return (
     <span
       className={cn(

--- a/src/components/invoice/invoice-table.tsx
+++ b/src/components/invoice/invoice-table.tsx
@@ -18,7 +18,11 @@ type InvoiceTableProps = {
   emptyState?: React.ReactNode;
 };
 
-export function InvoiceTable({ invoices, className, emptyState }: InvoiceTableProps) {
+export function InvoiceTable({
+  invoices,
+  className,
+  emptyState,
+}: InvoiceTableProps) {
   return (
     <div
       className={cn(

--- a/src/components/invoices/InvoiceCancellationModal.test.tsx
+++ b/src/components/invoices/InvoiceCancellationModal.test.tsx
@@ -1,35 +1,37 @@
-import { render, screen, fireEvent } from '@testing-library/react';
-import { describe, it, expect, vi } from 'vitest';
-import { InvoiceCancellationModal } from './InvoiceCancellationModal';
+import { render, screen, fireEvent } from "@testing-library/react";
+import { describe, it, expect, vi } from "vitest";
+import { InvoiceCancellationModal } from "./InvoiceCancellationModal";
 
-describe('InvoiceCancellationModal', () => {
-  it('renders modal when open is true', () => {
+describe("InvoiceCancellationModal", () => {
+  it("renders modal when open is true", () => {
     render(
       <InvoiceCancellationModal
         open={true}
         onOpenChange={vi.fn()}
         onConfirm={vi.fn()}
-      />
+      />,
     );
-    expect(screen.getByRole('dialog')).toBeInTheDocument();
-    expect(screen.getByText('Cancel Invoice')).toBeInTheDocument();
+    expect(screen.getByRole("dialog")).toBeInTheDocument();
+    expect(screen.getByText("Cancel Invoice")).toBeInTheDocument();
     expect(
-      screen.getByText('Are you sure you want to cancel this invoice? This cannot be undone.')
+      screen.getByText(
+        "Are you sure you want to cancel this invoice? This cannot be undone.",
+      ),
     ).toBeInTheDocument();
   });
 
-  it('does not render modal when open is false', () => {
+  it("does not render modal when open is false", () => {
     render(
       <InvoiceCancellationModal
         open={false}
         onOpenChange={vi.fn()}
         onConfirm={vi.fn()}
-      />
+      />,
     );
-    expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
+    expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
   });
 
-  it('calls onConfirm when confirm button is clicked', () => {
+  it("calls onConfirm when confirm button is clicked", () => {
     const handleConfirm = vi.fn();
     const handleOpenChange = vi.fn();
 
@@ -38,17 +40,19 @@ describe('InvoiceCancellationModal', () => {
         open={true}
         onOpenChange={handleOpenChange}
         onConfirm={handleConfirm}
-      />
+      />,
     );
 
-    const confirmButton = screen.getByRole('button', { name: /confirm cancellation/i });
+    const confirmButton = screen.getByRole("button", {
+      name: /confirm cancellation/i,
+    });
     fireEvent.click(confirmButton);
 
     expect(handleConfirm).toHaveBeenCalledTimes(1);
     expect(handleOpenChange).toHaveBeenCalledWith(false);
   });
 
-  it('calls onOpenChange with false when cancel button is clicked', () => {
+  it("calls onOpenChange with false when cancel button is clicked", () => {
     const handleOpenChange = vi.fn();
 
     render(
@@ -56,16 +60,16 @@ describe('InvoiceCancellationModal', () => {
         open={true}
         onOpenChange={handleOpenChange}
         onConfirm={vi.fn()}
-      />
+      />,
     );
 
-    const cancelButton = screen.getByRole('button', { name: 'Cancel' });
+    const cancelButton = screen.getByRole("button", { name: "Cancel" });
     fireEvent.click(cancelButton);
 
     expect(handleOpenChange).toHaveBeenCalledWith(false);
   });
 
-  it('calls onOpenChange with false when Escape key is pressed', () => {
+  it("calls onOpenChange with false when Escape key is pressed", () => {
     const handleOpenChange = vi.fn();
 
     render(
@@ -73,10 +77,13 @@ describe('InvoiceCancellationModal', () => {
         open={true}
         onOpenChange={handleOpenChange}
         onConfirm={vi.fn()}
-      />
+      />,
     );
 
-    fireEvent.keyDown(screen.getByRole('dialog'), { key: 'Escape', code: 'Escape' });
+    fireEvent.keyDown(screen.getByRole("dialog"), {
+      key: "Escape",
+      code: "Escape",
+    });
     expect(handleOpenChange).toHaveBeenCalledWith(false);
   });
 });

--- a/src/components/invoices/InvoiceCancellationModal.tsx
+++ b/src/components/invoices/InvoiceCancellationModal.tsx
@@ -1,9 +1,9 @@
-'use client';
+"use client";
 
-import * as React from 'react';
-import * as Dialog from '@radix-ui/react-dialog';
-import { X, AlertTriangle } from 'lucide-react';
-import { Button } from '@/components/ui/button';
+import * as React from "react";
+import * as Dialog from "@radix-ui/react-dialog";
+import { X, AlertTriangle } from "lucide-react";
+import { Button } from "@/components/ui/button";
 
 export interface InvoiceCancellationModalProps {
   open: boolean;
@@ -32,10 +32,11 @@ export function InvoiceCancellationModal({
               Cancel Invoice
             </Dialog.Title>
             <Dialog.Description className="text-sm text-slate-500">
-              Are you sure you want to cancel this invoice? This cannot be undone.
+              Are you sure you want to cancel this invoice? This cannot be
+              undone.
             </Dialog.Description>
           </div>
-          
+
           <div className="flex flex-col-reverse sm:flex-row sm:justify-end sm:space-x-2 mt-4">
             <Dialog.Close asChild>
               <Button variant="outline" className="mt-2 sm:mt-0">
@@ -46,7 +47,7 @@ export function InvoiceCancellationModal({
               Confirm Cancellation
             </Button>
           </div>
-          
+
           <Dialog.Close className="absolute right-4 top-4 rounded-sm opacity-70 ring-offset-white transition-opacity hover:opacity-100 focus:outline-none focus:ring-2 focus:ring-slate-950 focus:ring-offset-2 disabled:pointer-events-none data-[state=open]:bg-slate-100 data-[state=open]:text-slate-500">
             <X className="h-4 w-4" />
             <span className="sr-only">Close</span>

--- a/src/components/invoices/InvoiceRowActions.test.tsx
+++ b/src/components/invoices/InvoiceRowActions.test.tsx
@@ -1,23 +1,25 @@
-import { render, screen, waitFor } from '@testing-library/react';
-import userEvent from '@testing-library/user-event';
-import { describe, it, expect, vi } from 'vitest';
-import { InvoiceRowActions } from './InvoiceRowActions';
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, it, expect, vi } from "vitest";
+import { InvoiceRowActions } from "./InvoiceRowActions";
 
-describe('InvoiceRowActions', () => {
-  const mockInvoiceId = 'inv_123';
+describe("InvoiceRowActions", () => {
+  const mockInvoiceId = "inv_123";
 
-  it('renders the dropdown trigger button', () => {
+  it("renders the dropdown trigger button", () => {
     render(
       <InvoiceRowActions
         invoiceId={mockInvoiceId}
         onViewDetails={vi.fn()}
         onCopyPaymentLink={vi.fn()}
-      />
+      />,
     );
-    expect(screen.getByRole('button', { name: /invoice actions/i })).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: /invoice actions/i }),
+    ).toBeInTheDocument();
   });
 
-  it('opens dropdown and fires callbacks on click', async () => {
+  it("opens dropdown and fires callbacks on click", async () => {
     const user = userEvent.setup();
     const handleViewDetails = vi.fn();
     const handleCopyLink = vi.fn();
@@ -27,17 +29,19 @@ describe('InvoiceRowActions', () => {
         invoiceId={mockInvoiceId}
         onViewDetails={handleViewDetails}
         onCopyPaymentLink={handleCopyLink}
-      />
+      />,
     );
 
-    const triggerButton = screen.getByRole('button', { name: /invoice actions/i });
-    
+    const triggerButton = screen.getByRole("button", {
+      name: /invoice actions/i,
+    });
+
     // Open dropdown
     await user.click(triggerButton);
-    
-    const viewDetailsOption = await screen.findByText('View Details');
-    const copyLinkOption = await screen.findByText('Copy Payment Link');
-    
+
+    const viewDetailsOption = await screen.findByText("View Details");
+    const copyLinkOption = await screen.findByText("Copy Payment Link");
+
     expect(viewDetailsOption).toBeInTheDocument();
     expect(copyLinkOption).toBeInTheDocument();
 
@@ -48,7 +52,7 @@ describe('InvoiceRowActions', () => {
 
     // Click copy link (re-open first)
     await user.click(triggerButton);
-    const copyLinkOption2 = await screen.findByText('Copy Payment Link');
+    const copyLinkOption2 = await screen.findByText("Copy Payment Link");
     await user.click(copyLinkOption2);
     expect(handleCopyLink).toHaveBeenCalledWith(mockInvoiceId);
     expect(handleCopyLink).toHaveBeenCalledTimes(1);

--- a/src/components/invoices/InvoiceRowActions.tsx
+++ b/src/components/invoices/InvoiceRowActions.tsx
@@ -1,9 +1,9 @@
-'use client';
+"use client";
 
-import * as React from 'react';
-import * as DropdownMenu from '@radix-ui/react-dropdown-menu';
-import { MoreVertical, Eye, Link as LinkIcon } from 'lucide-react';
-import { Button } from '@/components/ui/button';
+import * as React from "react";
+import * as DropdownMenu from "@radix-ui/react-dropdown-menu";
+import { MoreVertical, Eye, Link as LinkIcon } from "lucide-react";
+import { Button } from "@/components/ui/button";
 
 export interface InvoiceRowActionsProps {
   invoiceId: string;
@@ -23,7 +23,7 @@ export function InvoiceRowActions({
           <MoreVertical className="h-4 w-4" />
         </Button>
       </DropdownMenu.Trigger>
-      
+
       <DropdownMenu.Portal>
         <DropdownMenu.Content
           align="end"
@@ -36,7 +36,7 @@ export function InvoiceRowActions({
             <Eye className="mr-2 h-4 w-4" />
             <span>View Details</span>
           </DropdownMenu.Item>
-          
+
           <DropdownMenu.Item
             className="relative flex cursor-pointer select-none items-center rounded-sm px-2 py-1.5 text-sm outline-none transition-colors focus:bg-slate-100 focus:text-slate-900 data-[disabled]:pointer-events-none data-[disabled]:opacity-50"
             onClick={() => onCopyPaymentLink(invoiceId)}

--- a/src/components/layout/DashboardShell.tsx
+++ b/src/components/layout/DashboardShell.tsx
@@ -10,10 +10,7 @@ export function DashboardShell({ children }: { children: React.ReactNode }) {
 
   return (
     <div className="flex h-screen overflow-hidden bg-background">
-      <Sidebar
-        isOpen={sidebarOpen}
-        onClose={() => setSidebarOpen(false)}
-      />
+      <Sidebar isOpen={sidebarOpen} onClose={() => setSidebarOpen(false)} />
 
       <div className="flex min-w-0 flex-1 flex-col overflow-hidden">
         {/* Mobile top bar */}

--- a/src/components/layout/Sidebar.tsx
+++ b/src/components/layout/Sidebar.tsx
@@ -3,7 +3,13 @@
 import Image from "next/image";
 import Link from "next/link";
 import { usePathname } from "next/navigation";
-import { LayoutDashboard, FileText, RefreshCw, Settings, X } from "lucide-react";
+import {
+  LayoutDashboard,
+  FileText,
+  RefreshCw,
+  Settings,
+  X,
+} from "lucide-react";
 
 import { cn } from "@/lib/utils";
 

--- a/src/components/pay/pay-manual-transfer-view.tsx
+++ b/src/components/pay/pay-manual-transfer-view.tsx
@@ -62,8 +62,10 @@ export function PayManualTransferView({
         <div>
           <p className="font-semibold mb-1">Important: Exact Amount Required</p>
           <p>
-            You must send the <strong>exact</strong> token amount shown below on the Stellar network.
-            Sending a different amount or using a different network may result in permanent loss of funds or a failed transaction.
+            You must send the <strong>exact</strong> token amount shown below on
+            the Stellar network. Sending a different amount or using a different
+            network may result in permanent loss of funds or a failed
+            transaction.
           </p>
         </div>
       </div>

--- a/src/components/pay/payment-success.tsx
+++ b/src/components/pay/payment-success.tsx
@@ -27,11 +27,7 @@ export function PaymentSuccess() {
           </p>
         </div>
 
-        <Button
-          type="button"
-          variant="outline"
-          className="bg-background"
-        >
+        <Button type="button" variant="outline" className="bg-background">
           <Download aria-hidden="true" />
           <span>Download Receipt</span>
         </Button>

--- a/src/components/pay/wallet-transaction-modal.tsx
+++ b/src/components/pay/wallet-transaction-modal.tsx
@@ -6,7 +6,9 @@ interface WalletTransactionModalProps {
   isOpen: boolean;
 }
 
-export function WalletTransactionModal({ isOpen }: WalletTransactionModalProps) {
+export function WalletTransactionModal({
+  isOpen,
+}: WalletTransactionModalProps) {
   if (!isOpen) return null;
 
   return (

--- a/src/components/payments/PaymentMethodTabs.test.tsx
+++ b/src/components/payments/PaymentMethodTabs.test.tsx
@@ -1,68 +1,72 @@
-import { render, screen, waitFor } from '@testing-library/react';
-import userEvent from '@testing-library/user-event';
-import { describe, it, expect } from 'vitest';
-import { PaymentMethodTabs } from './PaymentMethodTabs';
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, it, expect } from "vitest";
+import { PaymentMethodTabs } from "./PaymentMethodTabs";
 
-describe('PaymentMethodTabs', () => {
+describe("PaymentMethodTabs", () => {
   const walletContent = <div data-testid="wallet-content">Wallet Content</div>;
   const manualContent = <div data-testid="manual-content">Manual Content</div>;
 
-  it('renders default tab (wallet)', () => {
+  it("renders default tab (wallet)", () => {
     render(
       <PaymentMethodTabs
         walletContent={walletContent}
         manualTransferContent={manualContent}
-      />
+      />,
     );
 
-    expect(screen.getByRole('tab', { name: 'Connect Wallet' })).toBeInTheDocument();
-    expect(screen.getByRole('tab', { name: 'Manual Transfer' })).toBeInTheDocument();
+    expect(
+      screen.getByRole("tab", { name: "Connect Wallet" }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("tab", { name: "Manual Transfer" }),
+    ).toBeInTheDocument();
 
-    expect(screen.getByTestId('wallet-content')).toBeInTheDocument();
-    expect(screen.queryByTestId('manual-content')).not.toBeInTheDocument();
+    expect(screen.getByTestId("wallet-content")).toBeInTheDocument();
+    expect(screen.queryByTestId("manual-content")).not.toBeInTheDocument();
   });
 
-  it('switches to manual transfer tab', async () => {
+  it("switches to manual transfer tab", async () => {
     const user = userEvent.setup();
     render(
       <PaymentMethodTabs
         walletContent={walletContent}
         manualTransferContent={manualContent}
-      />
+      />,
     );
 
-    const manualTab = screen.getByRole('tab', { name: 'Manual Transfer' });
+    const manualTab = screen.getByRole("tab", { name: "Manual Transfer" });
     await user.click(manualTab);
 
     await waitFor(() => {
-      expect(screen.getByTestId('manual-content')).toBeInTheDocument();
+      expect(screen.getByTestId("manual-content")).toBeInTheDocument();
     });
-    expect(screen.queryByTestId('wallet-content')).not.toBeInTheDocument();
+    expect(screen.queryByTestId("wallet-content")).not.toBeInTheDocument();
   });
 
-  it('switches back to wallet tab', async () => {
+  it("switches back to wallet tab", async () => {
     const user = userEvent.setup();
     render(
       <PaymentMethodTabs
         walletContent={walletContent}
         manualTransferContent={manualContent}
-      />
+      />,
     );
 
-    const manualTab = screen.getByRole('tab', { name: 'Manual Transfer' });
-    const walletTab = screen.getByRole('tab', { name: 'Connect Wallet' });
+    const manualTab = screen.getByRole("tab", { name: "Manual Transfer" });
+    const walletTab = screen.getByRole("tab", { name: "Connect Wallet" });
 
     // Switch to manual
     await user.click(manualTab);
     await waitFor(() => {
-      expect(screen.getByTestId('manual-content')).toBeInTheDocument();
+      expect(screen.getByTestId("manual-content")).toBeInTheDocument();
     });
 
     // Switch back to wallet
     await user.click(walletTab);
     await waitFor(() => {
-      expect(screen.getByTestId('wallet-content')).toBeInTheDocument();
+      expect(screen.getByTestId("wallet-content")).toBeInTheDocument();
     });
-    expect(screen.queryByTestId('manual-content')).not.toBeInTheDocument();
+    expect(screen.queryByTestId("manual-content")).not.toBeInTheDocument();
   });
 });

--- a/src/components/payments/PaymentMethodTabs.tsx
+++ b/src/components/payments/PaymentMethodTabs.tsx
@@ -1,8 +1,8 @@
-'use client';
+"use client";
 
-import * as React from 'react';
-import * as Tabs from '@radix-ui/react-tabs';
-import { cn } from '@/lib/utils';
+import * as React from "react";
+import * as Tabs from "@radix-ui/react-tabs";
+import { cn } from "@/lib/utils";
 
 export interface PaymentMethodTabsProps {
   walletContent: React.ReactNode;
@@ -31,14 +31,14 @@ export function PaymentMethodTabs({
           Manual Transfer
         </Tabs.Trigger>
       </Tabs.List>
-      
+
       <Tabs.Content
         value="wallet"
         className="mt-2 ring-offset-white focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-slate-950 focus-visible:ring-offset-2"
       >
         {walletContent}
       </Tabs.Content>
-      
+
       <Tabs.Content
         value="manual"
         className="mt-2 ring-offset-white focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-slate-950 focus-visible:ring-offset-2"

--- a/src/components/profile/ProfileDetailsForm.test.tsx
+++ b/src/components/profile/ProfileDetailsForm.test.tsx
@@ -1,84 +1,91 @@
-import { render, screen, fireEvent, waitFor } from '@testing-library/react';
-import { describe, it, expect, vi } from 'vitest';
-import { ProfileDetailsForm } from './ProfileDetailsForm';
-import { mockMerchantProfile } from '@/mocks/merchantProfile';
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+import { describe, it, expect, vi } from "vitest";
+import { ProfileDetailsForm } from "./ProfileDetailsForm";
+import { mockMerchantProfile } from "@/mocks/merchantProfile";
 
-describe('ProfileDetailsForm', () => {
-  it('renders initial data correctly', () => {
+describe("ProfileDetailsForm", () => {
+  it("renders initial data correctly", () => {
     render(
       <ProfileDetailsForm
         initialData={mockMerchantProfile}
         onSubmit={vi.fn()}
-      />
+      />,
     );
 
-    expect(screen.getByLabelText('Business Name')).toHaveValue('Acme Corp');
-    expect(screen.getByLabelText('Category')).toHaveValue('Software Services');
-    expect(screen.getByLabelText('Description')).toHaveValue('Leading provider of excellent software solutions.');
+    expect(screen.getByLabelText("Business Name")).toHaveValue("Acme Corp");
+    expect(screen.getByLabelText("Category")).toHaveValue("Software Services");
+    expect(screen.getByLabelText("Description")).toHaveValue(
+      "Leading provider of excellent software solutions.",
+    );
   });
 
-  it('updates input values when changed', () => {
+  it("updates input values when changed", () => {
     render(
       <ProfileDetailsForm
         initialData={mockMerchantProfile}
         onSubmit={vi.fn()}
-      />
+      />,
     );
 
-    const businessNameInput = screen.getByLabelText('Business Name');
-    fireEvent.change(businessNameInput, { target: { value: 'Globex Inc' } });
+    const businessNameInput = screen.getByLabelText("Business Name");
+    fireEvent.change(businessNameInput, { target: { value: "Globex Inc" } });
 
-    expect(businessNameInput).toHaveValue('Globex Inc');
+    expect(businessNameInput).toHaveValue("Globex Inc");
   });
 
-  it('fires onSubmit with updated values when submitted', async () => {
+  it("fires onSubmit with updated values when submitted", async () => {
     const handleSubmit = vi.fn();
 
     render(
       <ProfileDetailsForm
         initialData={mockMerchantProfile}
         onSubmit={handleSubmit}
-      />
+      />,
     );
 
-    const categoryInput = screen.getByLabelText('Category');
-    fireEvent.change(categoryInput, { target: { value: 'Hardware' } });
+    const categoryInput = screen.getByLabelText("Category");
+    fireEvent.change(categoryInput, { target: { value: "Hardware" } });
 
-    const submitButton = screen.getByRole('button', { name: 'Save Changes' });
+    const submitButton = screen.getByRole("button", { name: "Save Changes" });
     fireEvent.click(submitButton);
 
     await waitFor(() => {
       expect(handleSubmit).toHaveBeenCalledWith({
         ...mockMerchantProfile,
-        category: 'Hardware',
+        category: "Hardware",
       });
       expect(handleSubmit).toHaveBeenCalledTimes(1);
     });
   });
 
-  it('shows loading state while submitting', async () => {
+  it("shows loading state while submitting", async () => {
     let resolveSubmit: () => void;
-    const handleSubmit = vi.fn(() => new Promise<void>((resolve) => {
-      resolveSubmit = resolve;
-    }));
+    const handleSubmit = vi.fn(
+      () =>
+        new Promise<void>((resolve) => {
+          resolveSubmit = resolve;
+        }),
+    );
 
     render(
       <ProfileDetailsForm
         initialData={mockMerchantProfile}
         onSubmit={handleSubmit}
-      />
+      />,
     );
 
-    const submitButton = screen.getByRole('button', { name: 'Save Changes' });
+    const submitButton = screen.getByRole("button", { name: "Save Changes" });
     fireEvent.click(submitButton);
 
-    expect(screen.getByRole('button', { name: 'Saving...' })).toBeDisabled();
+    expect(screen.getByRole("button", { name: "Saving..." })).toBeDisabled();
 
     // @ts-ignore - resolveSubmit is assigned synchronously in the mock
     resolveSubmit();
 
     await waitFor(() => {
-      expect(screen.getByRole('button', { name: 'Save Changes' })).not.toBeDisabled();
+      expect(
+        screen.getByRole("button", { name: "Save Changes" }),
+      ).not.toBeDisabled();
     });
   });
 });

--- a/src/components/profile/ProfileDetailsForm.tsx
+++ b/src/components/profile/ProfileDetailsForm.tsx
@@ -1,9 +1,9 @@
-'use client';
+"use client";
 
-import * as React from 'react';
-import { useState } from 'react';
-import { ProfileDetailsFormData } from '@/types/profile';
-import { Button } from '@/components/ui/button';
+import * as React from "react";
+import { useState } from "react";
+import { ProfileDetailsFormData } from "@/types/profile";
+import { Button } from "@/components/ui/button";
 
 export interface ProfileDetailsFormProps {
   initialData: ProfileDetailsFormData;
@@ -18,7 +18,7 @@ export function ProfileDetailsForm({
   const [isSubmitting, setIsSubmitting] = useState(false);
 
   const handleChange = (
-    e: React.ChangeEvent<HTMLInputElement | HTMLTextAreaElement>
+    e: React.ChangeEvent<HTMLInputElement | HTMLTextAreaElement>,
   ) => {
     const { name, value } = e.target;
     setFormData((prev) => ({
@@ -95,7 +95,7 @@ export function ProfileDetailsForm({
 
       <div className="flex justify-end">
         <Button type="submit" disabled={isSubmitting}>
-          {isSubmitting ? 'Saving...' : 'Save Changes'}
+          {isSubmitting ? "Saving..." : "Save Changes"}
         </Button>
       </div>
     </form>

--- a/src/components/settings/api-key-table.tsx
+++ b/src/components/settings/api-key-table.tsx
@@ -71,9 +71,7 @@ export function ApiKeyTable({
                   {formatDate(apiKey.createdAt)}
                 </td>
                 <td className="px-4 py-3 text-muted-foreground">
-                  {apiKey.lastUsedAt
-                    ? formatDate(apiKey.lastUsedAt)
-                    : "Never"}
+                  {apiKey.lastUsedAt ? formatDate(apiKey.lastUsedAt) : "Never"}
                 </td>
                 <td className="px-4 py-3 text-right">
                   <Button

--- a/src/components/settings/generate-api-key-modal.tsx
+++ b/src/components/settings/generate-api-key-modal.tsx
@@ -44,7 +44,9 @@ export function GenerateApiKeyModal({
       await onSubmit(trimmed);
       onClose();
     } catch (err) {
-      setError(err instanceof Error ? err.message : "Failed to generate API key");
+      setError(
+        err instanceof Error ? err.message : "Failed to generate API key",
+      );
     } finally {
       setIsSubmitting(false);
     }
@@ -112,11 +114,16 @@ export function GenerateApiKeyModal({
               placeholder="e.g. Production Backend"
               disabled={isSubmitting}
               className={`rounded-md border bg-background px-3 py-2 text-sm shadow-sm transition-all focus:outline-none focus:ring-2 focus:ring-indigo-500 disabled:opacity-60 text-foreground ${
-                error ? "border-destructive focus:ring-destructive" : "border-input focus:ring-ring"
+                error
+                  ? "border-destructive focus:ring-destructive"
+                  : "border-input focus:ring-ring"
               }`}
             />
             {error && (
-              <p role="alert" className="text-xs font-semibold text-destructive mt-0.5">
+              <p
+                role="alert"
+                className="text-xs font-semibold text-destructive mt-0.5"
+              >
                 {error}
               </p>
             )}

--- a/src/components/settings/settings-nav.tsx
+++ b/src/components/settings/settings-nav.tsx
@@ -27,8 +27,7 @@ export function SettingsNav() {
     >
       {items.map(({ href, label, icon: Icon }) => {
         const isActive =
-          pathname === href ||
-          (pathname?.startsWith(href + "/") ?? false);
+          pathname === href || (pathname?.startsWith(href + "/") ?? false);
 
         return (
           <Link

--- a/src/components/subscription/subscriber-table.test.tsx
+++ b/src/components/subscription/subscriber-table.test.tsx
@@ -47,9 +47,7 @@ describe("SubscriberTable", () => {
   });
 
   it("renders a custom empty state when provided", () => {
-    render(
-      <SubscriberTable subscribers={[]} emptyState="Nobody here." />,
-    );
+    render(<SubscriberTable subscribers={[]} emptyState="Nobody here." />);
 
     expect(screen.getByText("Nobody here.")).toBeInTheDocument();
   });

--- a/src/components/subscription/subscription-plan-card.tsx
+++ b/src/components/subscription/subscription-plan-card.tsx
@@ -44,10 +44,7 @@ export function SubscriptionPlanCard({
         className,
       )}
     >
-      <div
-        aria-hidden
-        className="absolute inset-y-0 left-0 w-1 bg-primary"
-      />
+      <div aria-hidden className="absolute inset-y-0 left-0 w-1 bg-primary" />
 
       <div className="pl-3">
         <div className="flex items-start justify-between gap-4">

--- a/src/components/timeline/invoice-timeline.tsx
+++ b/src/components/timeline/invoice-timeline.tsx
@@ -49,10 +49,7 @@ export function InvoiceTimeline({
                 className="z-10 mt-1 size-3 shrink-0 rounded-full border-2 border-primary bg-background"
               />
               {!isLast ? (
-                <span
-                  aria-hidden
-                  className="w-px flex-1 bg-border"
-                />
+                <span aria-hidden className="w-px flex-1 bg-border" />
               ) : null}
             </div>
             <div className="flex flex-col gap-0.5 pb-2">

--- a/src/components/ui/skeleton.tsx
+++ b/src/components/ui/skeleton.tsx
@@ -1,4 +1,4 @@
-import { cn } from "@/lib/utils"
+import { cn } from "@/lib/utils";
 
 function Skeleton({
   className,
@@ -9,7 +9,7 @@ function Skeleton({
       className={cn("animate-pulse rounded-md bg-muted", className)}
       {...props}
     />
-  )
+  );
 }
 
-export { Skeleton }
+export { Skeleton };

--- a/src/components/ui/token-selector.tsx
+++ b/src/components/ui/token-selector.tsx
@@ -73,7 +73,11 @@ export interface TokenSelectorProps {
   disabled?: boolean;
 }
 
-export function TokenSelector({ value, onChange, disabled }: TokenSelectorProps) {
+export function TokenSelector({
+  value,
+  onChange,
+  disabled,
+}: TokenSelectorProps) {
   const [isOpen, setIsOpen] = useState(false);
   const containerRef = useRef<HTMLDivElement>(null);
 
@@ -81,7 +85,10 @@ export function TokenSelector({ value, onChange, disabled }: TokenSelectorProps)
 
   useEffect(() => {
     function handleClickOutside(event: MouseEvent) {
-      if (containerRef.current && !containerRef.current.contains(event.target as Node)) {
+      if (
+        containerRef.current &&
+        !containerRef.current.contains(event.target as Node)
+      ) {
         setIsOpen(false);
       }
     }
@@ -106,17 +113,24 @@ export function TokenSelector({ value, onChange, disabled }: TokenSelectorProps)
         aria-expanded={isOpen}
         className={cn(
           "flex w-full items-center justify-between rounded-md border border-input bg-background px-3 py-2 text-sm shadow-sm transition-all focus:outline-none focus:ring-2 focus:ring-ring disabled:cursor-not-allowed disabled:opacity-50 text-left",
-          isOpen && "ring-2 ring-ring"
+          isOpen && "ring-2 ring-ring",
         )}
       >
         <span className="flex items-center gap-2">
           {selectedToken.icon}
-          <span className="font-medium text-foreground">{selectedToken.symbol}</span>
+          <span className="font-medium text-foreground">
+            {selectedToken.symbol}
+          </span>
           <span className="text-xs text-muted-foreground hidden sm:inline">
             ({selectedToken.name})
           </span>
         </span>
-        <ChevronDown className={cn("h-4 w-4 text-muted-foreground transition-transform duration-200", isOpen && "rotate-180")} />
+        <ChevronDown
+          className={cn(
+            "h-4 w-4 text-muted-foreground transition-transform duration-200",
+            isOpen && "rotate-180",
+          )}
+        />
       </button>
 
       {isOpen && (
@@ -135,13 +149,16 @@ export function TokenSelector({ value, onChange, disabled }: TokenSelectorProps)
                 onClick={() => handleSelect(token.symbol)}
                 className={cn(
                   "relative flex w-full cursor-pointer select-none items-center rounded-sm py-1.5 pl-2 pr-8 text-sm outline-none transition-colors hover:bg-accent hover:text-accent-foreground data-[disabled]:pointer-events-none data-[disabled]:opacity-50",
-                  isSelected && "bg-accent/50 text-accent-foreground font-medium"
+                  isSelected &&
+                    "bg-accent/50 text-accent-foreground font-medium",
                 )}
               >
                 <span className="flex items-center gap-2">
                   {token.icon}
                   <span>{token.symbol}</span>
-                  <span className="text-xs text-muted-foreground">({token.name})</span>
+                  <span className="text-xs text-muted-foreground">
+                    ({token.name})
+                  </span>
                 </span>
                 {isSelected && (
                   <span className="absolute right-2 flex h-3.5 w-3.5 items-center justify-center">

--- a/src/lib/billing-plan-schema.ts
+++ b/src/lib/billing-plan-schema.ts
@@ -10,7 +10,12 @@
 
 import { z } from "zod";
 
-export const billingIntervals = ["daily", "weekly", "monthly", "yearly"] as const;
+export const billingIntervals = [
+  "daily",
+  "weekly",
+  "monthly",
+  "yearly",
+] as const;
 
 export type BillingInterval = (typeof billingIntervals)[number];
 
@@ -22,21 +27,14 @@ export const billingIntervalLabels: Record<BillingInterval, string> = {
 };
 
 export const billingPlanCreateSchema = z.object({
-  name: z
-    .string()
-    .trim()
-    .min(1, "Plan name is required"),
-  amount: z
-    .coerce
+  name: z.string().trim().min(1, "Plan name is required"),
+  amount: z.coerce
     .number({ invalid_type_error: "Amount must be a number" })
     .positive("Amount must be greater than zero"),
   interval: z.enum(billingIntervals, {
     errorMap: () => ({ message: "Select a billing interval" }),
   }),
-  description: z
-    .string()
-    .trim()
-    .min(1, "Description is required"),
+  description: z.string().trim().min(1, "Description is required"),
   customerEmail: z
     .string()
     .trim()
@@ -54,7 +52,10 @@ export type BillingPlanCreateInput = z.infer<typeof billingPlanCreateSchema>;
  */
 export function validateBillingPlanCreate(input: unknown):
   | { ok: true; value: BillingPlanCreateInput }
-  | { ok: false; errors: Partial<Record<keyof BillingPlanCreateInput, string>> } {
+  | {
+      ok: false;
+      errors: Partial<Record<keyof BillingPlanCreateInput, string>>;
+    } {
   const parsed = billingPlanCreateSchema.safeParse(input);
   if (parsed.success) return { ok: true, value: parsed.data };
   const errors: Partial<Record<keyof BillingPlanCreateInput, string>> = {};

--- a/src/lib/invoice-schema.ts
+++ b/src/lib/invoice-schema.ts
@@ -25,14 +25,10 @@ function todayIso(): string {
 }
 
 export const invoiceCreateSchema = z.object({
-  amount: z
-    .coerce
+  amount: z.coerce
     .number({ invalid_type_error: "Amount must be a number" })
     .positive("Amount must be greater than zero"),
-  description: z
-    .string()
-    .trim()
-    .min(1, "Description is required"),
+  description: z.string().trim().min(1, "Description is required"),
   customerEmail: z
     .string()
     .trim()
@@ -58,7 +54,9 @@ export type InvoiceCreateInput = z.infer<typeof invoiceCreateSchema>;
  * for the parsed input or `{ ok: false, errors }` with a per-field
  * map ready to drive the red error text under each input.
  */
-export function validateInvoiceCreate(input: unknown):
+export function validateInvoiceCreate(
+  input: unknown,
+):
   | { ok: true; value: InvoiceCreateInput }
   | { ok: false; errors: Partial<Record<keyof InvoiceCreateInput, string>> } {
   const parsed = invoiceCreateSchema.safeParse(input);

--- a/src/lib/invoice-types.ts
+++ b/src/lib/invoice-types.ts
@@ -1,4 +1,9 @@
-export type InvoiceStatus = "draft" | "pending" | "paid" | "overdue" | "cancelled";
+export type InvoiceStatus =
+  | "draft"
+  | "pending"
+  | "paid"
+  | "overdue"
+  | "cancelled";
 
 export type Invoice = {
   referenceId: string;
@@ -10,4 +15,3 @@ export type Invoice = {
   payerEmail?: string;
   expiration?: string;
 };
-

--- a/src/lib/lucide-react.tsx
+++ b/src/lib/lucide-react.tsx
@@ -6,7 +6,10 @@ export type LucideIcon = React.ComponentType<React.SVGProps<SVGSVGElement>>;
 
 type IconProps = React.SVGProps<SVGSVGElement>;
 
-function IconBase({ children, ...props }: IconProps & { children?: React.ReactNode }) {
+function IconBase({
+  children,
+  ...props
+}: IconProps & { children?: React.ReactNode }) {
   return (
     <svg
       width="24"

--- a/src/lib/lucide-react.tsx
+++ b/src/lib/lucide-react.tsx
@@ -87,6 +87,22 @@ export function ChevronDown(props: IconProps) {
   );
 }
 
+export function ChevronLeft(props: IconProps) {
+  return (
+    <IconBase {...props}>
+      <path d="m15 18-6-6 6-6" />
+    </IconBase>
+  );
+}
+
+export function ChevronRight(props: IconProps) {
+  return (
+    <IconBase {...props}>
+      <path d="m9 18 6-6-6-6" />
+    </IconBase>
+  );
+}
+
 export function ClipboardCopy(props: IconProps) {
   return (
     <IconBase {...props}>
@@ -176,6 +192,15 @@ export function UserCircle(props: IconProps) {
       <circle cx="12" cy="12" r="10" />
       <circle cx="12" cy="10" r="3" />
       <path d="M6.5 19a6 6 0 0 1 11 0" />
+    </IconBase>
+  );
+}
+
+export function UserRound(props: IconProps) {
+  return (
+    <IconBase {...props}>
+      <circle cx="12" cy="8" r="4" />
+      <path d="M6 20a6 6 0 0 1 12 0" />
     </IconBase>
   );
 }
@@ -289,6 +314,82 @@ export function Share2(props: IconProps) {
       <circle cx="18" cy="19" r="3" />
       <path d="M8.6 13.5 15.4 17.5" />
       <path d="M15.4 6.5 8.6 10.5" />
+    </IconBase>
+  );
+}
+
+export function Building2(props: IconProps) {
+  return (
+    <IconBase {...props}>
+      <path d="M6 22V6a2 2 0 0 1 2-2h8a2 2 0 0 1 2 2v16" />
+      <path d="M2 22h20" />
+      <path d="M10 6V2h4v4" />
+      <path d="M10 10h1" />
+      <path d="M13 10h1" />
+      <path d="M10 14h1" />
+      <path d="M13 14h1" />
+      <path d="M10 18h4" />
+    </IconBase>
+  );
+}
+
+export function MailCheck(props: IconProps) {
+  return (
+    <IconBase {...props}>
+      <path d="M22 6 12 13 2 6" />
+      <rect x="2" y="4" width="20" height="16" rx="2" />
+      <path d="m9 12 2 2 4-4" />
+    </IconBase>
+  );
+}
+
+export function Menu(props: IconProps) {
+  return (
+    <IconBase {...props}>
+      <path d="M4 6h16" />
+      <path d="M4 12h16" />
+      <path d="M4 18h16" />
+    </IconBase>
+  );
+}
+
+export function LogOut(props: IconProps) {
+  return (
+    <IconBase {...props}>
+      <path d="M9 21H5a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h4" />
+      <path d="m16 17 5-5-5-5" />
+      <path d="M21 12H9" />
+    </IconBase>
+  );
+}
+
+export function LayoutDashboard(props: IconProps) {
+  return (
+    <IconBase {...props}>
+      <rect x="3" y="3" width="7" height="8" rx="1" />
+      <rect x="14" y="3" width="7" height="5" rx="1" />
+      <rect x="14" y="12" width="7" height="9" rx="1" />
+      <rect x="3" y="15" width="7" height="6" rx="1" />
+    </IconBase>
+  );
+}
+
+export function RefreshCw(props: IconProps) {
+  return (
+    <IconBase {...props}>
+      <path d="M21 2v6h-6" />
+      <path d="M3 22v-6h6" />
+      <path d="M20 8a9 9 0 0 0-15-3L3 8" />
+      <path d="M4 16a9 9 0 0 0 15 3l2-3" />
+    </IconBase>
+  );
+}
+
+export function Settings(props: IconProps) {
+  return (
+    <IconBase {...props}>
+      <circle cx="12" cy="12" r="3" />
+      <path d="M19.4 15a1.7 1.7 0 0 0 .3 1.8l.1.1a2 2 0 1 1-2.8 2.8l-.1-.1a1.7 1.7 0 0 0-1.8-.3 1.7 1.7 0 0 0-1 1.5V21a2 2 0 1 1-4 0v-.2a1.7 1.7 0 0 0-1-1.5 1.7 1.7 0 0 0-1.8.3l-.1.1a2 2 0 1 1-2.8-2.8l.1-.1a1.7 1.7 0 0 0 .3-1.8 1.7 1.7 0 0 0-1.5-1H3a2 2 0 1 1 0-4h.2a1.7 1.7 0 0 0 1.5-1 1.7 1.7 0 0 0-.3-1.8l-.1-.1a2 2 0 1 1 2.8-2.8l.1.1a1.7 1.7 0 0 0 1.8.3H9a1.7 1.7 0 0 0 1-1.5V3a2 2 0 1 1 4 0v.2a1.7 1.7 0 0 0 1 1.5 1.7 1.7 0 0 0 1.8-.3l.1-.1a2 2 0 1 1 2.8 2.8l-.1.1a1.7 1.7 0 0 0-.3 1.8V9c0 .7.4 1.3 1 1.5h.2a2 2 0 1 1 0 4H21c-.7 0-1.3.4-1.6 1Z" />
     </IconBase>
   );
 }

--- a/src/lib/lucide-react.tsx
+++ b/src/lib/lucide-react.tsx
@@ -47,6 +47,16 @@ export function AlertTriangle(props: IconProps) {
   );
 }
 
+export function AlertCircle(props: IconProps) {
+  return (
+    <IconBase {...props}>
+      <circle cx="12" cy="12" r="10" />
+      <path d="M12 8v4" />
+      <path d="M12 16h.01" />
+    </IconBase>
+  );
+}
+
 export function Check(props: IconProps) {
   return (
     <IconBase {...props}>
@@ -317,6 +327,53 @@ export function Share2(props: IconProps) {
       <circle cx="18" cy="19" r="3" />
       <path d="M8.6 13.5 15.4 17.5" />
       <path d="M15.4 6.5 8.6 10.5" />
+    </IconBase>
+  );
+}
+
+export function Plus(props: IconProps) {
+  return (
+    <IconBase {...props}>
+      <path d="M12 5v14" />
+      <path d="M5 12h14" />
+    </IconBase>
+  );
+}
+
+export function MoreVertical(props: IconProps) {
+  return (
+    <IconBase {...props}>
+      <circle cx="12" cy="5" r="1.5" />
+      <circle cx="12" cy="12" r="1.5" />
+      <circle cx="12" cy="19" r="1.5" />
+    </IconBase>
+  );
+}
+
+export function Eye(props: IconProps) {
+  return (
+    <IconBase {...props}>
+      <path d="M2 12s3.5-6 10-6 10 6 10 6-3.5 6-10 6-10-6-10-6Z" />
+      <circle cx="12" cy="12" r="3" />
+    </IconBase>
+  );
+}
+
+export function Link(props: IconProps) {
+  return (
+    <IconBase {...props}>
+      <path d="M10 13a5 5 0 0 0 7.07 0l1.41-1.41a5 5 0 0 0-7.07-7.07L10 5" />
+      <path d="M14 11a5 5 0 0 0-7.07 0l-1.41 1.41a5 5 0 1 0 7.07 7.07L14 19" />
+    </IconBase>
+  );
+}
+
+export function Download(props: IconProps) {
+  return (
+    <IconBase {...props}>
+      <path d="M12 3v12" />
+      <path d="m7 10 5 5 5-5" />
+      <path d="M5 21h14" />
     </IconBase>
   );
 }

--- a/src/lib/nav-items.ts
+++ b/src/lib/nav-items.ts
@@ -18,4 +18,3 @@ export const navItems: NavItem[] = [
   { href: "/customers", label: "Customers", icon: Users },
   { href: "/settings", label: "Settings", icon: Settings },
 ];
-

--- a/src/mocks/merchantProfile.ts
+++ b/src/mocks/merchantProfile.ts
@@ -1,8 +1,8 @@
-import { MerchantProfile } from '@/types/profile';
+import { MerchantProfile } from "@/types/profile";
 
 export const mockMerchantProfile: MerchantProfile = {
-  id: 'merch_001',
-  businessName: 'Acme Corp',
-  category: 'Software Services',
-  description: 'Leading provider of excellent software solutions.',
+  id: "merch_001",
+  businessName: "Acme Corp",
+  category: "Software Services",
+  description: "Leading provider of excellent software solutions.",
 };

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,15 +1,15 @@
-import { defineConfig } from 'vitest/config';
-import react from '@vitejs/plugin-react';
-import path from 'path';
+import { defineConfig } from "vitest/config";
+import react from "@vitejs/plugin-react";
+import path from "path";
 
 export default defineConfig({
   plugins: [react()],
   test: {
-    environment: 'jsdom',
+    environment: "jsdom",
     globals: true,
-    setupFiles: './vitest.setup.ts',
+    setupFiles: "./vitest.setup.ts",
     alias: {
-      '@': path.resolve(__dirname, './src'),
+      "@": path.resolve(__dirname, "./src"),
     },
   },
 });

--- a/vitest.setup.ts
+++ b/vitest.setup.ts
@@ -1,1 +1,1 @@
-import '@testing-library/jest-dom';
+import "@testing-library/jest-dom";


### PR DESCRIPTION
## Summary

Assembles the dashboard route into the intended overview layout and unblocks local previewing by fixing the missing chart dependency and local icon shim gaps. Also removes the nested dashboard shell that was causing duplicate navigation on large screens.

Closes #17

## Changes

- assembled `src/app/(dashboard)/dashboard/page.tsx` with stat cards, `RevenueChart`, and `RecentActivity`
- added seeded recent activity data for the dashboard preview state
- removed the nested dashboard shell wrapper from `src/app/(dashboard)/dashboard/layout.tsx` to prevent duplicate navbars
- expanded the local `lucide-react` shim with the missing icons needed by the register flow and dashboard shell
- added `recharts` to project dependencies so `RevenueChart` can build locally

## Verification

- [x] `npm run typecheck`
- [x] `npm run format:check`

## Notes

- `npm run typecheck` was not fully clean before this change due to unrelated missing test/dev dependencies in the repo.

## Screenshot
Desktop screen: 
<img width="1580" height="1359" alt="image" src="https://github.com/user-attachments/assets/a483a8f0-cffa-47af-84c4-fb8d0c6278e8" />
Mobile screen: 
<img width="1580" height="1359" alt="image" src="https://github.com/user-attachments/assets/959f1de7-5178-4ebb-8f06-a64b0484f0d9" />


