### PR TITLE
feat: extract wallet session hook, connect button, address badge, and route guard

### DIFF
--- a/src/app/(dashboard)/dashboard/page.tsx
+++ b/src/app/(dashboard)/dashboard/page.tsx
@@ -1,6 +1,7 @@
 import { DollarSign, FileText, TrendingUp, Users } from "lucide-react";
 
 import RecentActivity from "@/components/RecentActivity";
+import { RequireWalletSession } from "@/components/require-wallet-session";
 import RevenueChart from "@/components/RevenueChart";
 import { ApiKeyManagement } from "@/components/dashboard/api-key-management";
 import { StatCard } from "@/components/StatCard";
@@ -47,51 +48,53 @@ const RECENT_ACTIVITY_EVENTS: ActivityEvent[] = [
 
 export default function DashboardPage() {
   return (
-    <div className="space-y-6">
-      <div>
-        <h1 className="text-2xl font-bold text-foreground">Dashboard</h1>
-        <p className="mt-1 text-sm text-muted-foreground">
-          Welcome back. Here&apos;s an overview of your business.
-        </p>
-      </div>
-
-      <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-4">
-        <StatCard
-          title="Total revenue"
-          value="$12,430"
-          icon={<DollarSign className="size-4" />}
-          trend={12.5}
-        />
-        <StatCard
-          title="Active invoices"
-          value="24"
-          icon={<FileText className="size-4" />}
-          trend={-3.2}
-        />
-        <StatCard
-          title="Total customers"
-          value="138"
-          icon={<Users className="size-4" />}
-          trend={8.1}
-        />
-        <StatCard
-          title="Payment volume"
-          value="$9,870"
-          icon={<TrendingUp className="size-4" />}
-          trend={5.4}
-        />
-      </div>
-
-      <div className="grid grid-cols-1 gap-4 lg:grid-cols-3">
-        <div className="lg:col-span-2">
-          <RevenueChart />
+    <RequireWalletSession>
+      <div className="space-y-6">
+        <div>
+          <h1 className="text-2xl font-bold text-foreground">Dashboard</h1>
+          <p className="mt-1 text-sm text-muted-foreground">
+            Welcome back. Here&apos;s an overview of your business.
+          </p>
         </div>
-        <RecentActivity events={RECENT_ACTIVITY_EVENTS} className="h-full" />
+
+        <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-4">
+          <StatCard
+            title="Total revenue"
+            value="$12,430"
+            icon={<DollarSign className="size-4" />}
+            trend={12.5}
+          />
+          <StatCard
+            title="Active invoices"
+            value="24"
+            icon={<FileText className="size-4" />}
+            trend={-3.2}
+          />
+          <StatCard
+            title="Total customers"
+            value="138"
+            icon={<Users className="size-4" />}
+            trend={8.1}
+          />
+          <StatCard
+            title="Payment volume"
+            value="$9,870"
+            icon={<TrendingUp className="size-4" />}
+            trend={5.4}
+          />
+        </div>
+
+        <div className="grid grid-cols-1 gap-4 lg:grid-cols-3">
+          <div className="lg:col-span-2">
+            <RevenueChart />
+          </div>
+          <RecentActivity events={RECENT_ACTIVITY_EVENTS} className="h-full" />
+        </div>
+
+        <DashboardActions />
+
+        <ApiKeyManagement />
       </div>
-
-      <DashboardActions />
-
-      <ApiKeyManagement />
-    </div>
+    </RequireWalletSession>
   );
 }

--- a/src/app/sign-in/sign-in-client.tsx
+++ b/src/app/sign-in/sign-in-client.tsx
@@ -1,138 +1,25 @@
 "use client";
 
-import { useMemo, useState } from "react";
-import { BadgeCheck, Loader2, WalletCards } from "lucide-react";
+import { BadgeCheck, WalletCards } from "lucide-react";
 import { useRouter } from "next/navigation";
 
-import { Button } from "@/components/ui/button";
-import {
-  getMerchantProfile,
-  MERCHANT_SESSION_KEY,
-} from "@/lib/merchant-storage";
-
-type AuthStatus = "idle" | "connecting" | "signing" | "verified" | "error";
-
-type WalletSession = {
-  address: string;
-  challenge: string;
-  signature: string;
-  signedAt: string;
-};
-
-function createChallenge(address: string) {
-  const issuedAt = new Date().toISOString();
-  const nonce =
-    typeof crypto !== "undefined" && "randomUUID" in crypto
-      ? crypto.randomUUID()
-      : `${Date.now()}-${Math.random().toString(16).slice(2)}`;
-
-  return [
-    "Shade Merchant Sign In",
-    "",
-    "Sign this message to prove you control this Stellar wallet.",
-    "This request will not move funds or create a transaction.",
-    "",
-    `Wallet: ${address}`,
-    `Nonce: ${nonce}`,
-    `Issued At: ${issuedAt}`,
-  ].join("\n");
-}
-
-// async function verifySignedMessage(
-//   challenge: string,
-//   signedMessage: string,
-//   signerAddress: string,
-// ) {
-//   const { Keypair } = await import("@stellar/stellar-sdk");
-//   const keypair = Keypair.fromPublicKey(signerAddress);
-//   const messageBytes = Buffer.from(challenge, "utf8");
-//   const signatureBytes = Buffer.from(signedMessage, "base64");
-//
-//   return keypair.verify(messageBytes, signatureBytes);
-// }
+import { WalletConnectButton } from "@/components/wallet-connect-button";
+import { useWalletConnect } from "@/hooks/use-wallet-connect";
+import { getMerchantProfile } from "@/lib/merchant-storage";
 
 export function SignInClient() {
   const router = useRouter();
-  const [status, setStatus] = useState<AuthStatus>("idle");
-  const [error, setError] = useState<string | null>(null);
-  const [session, setSession] = useState<WalletSession | null>(null);
-
-  const buttonLabel = useMemo(() => {
-    if (status === "connecting") return "Connecting wallet";
-    if (status === "signing") return "Waiting for signature";
-    if (status === "verified") return "Wallet verified";
-    return "Connect wallet to sign in";
-  }, [status]);
+  const { status, error, session, connect } = useWalletConnect();
 
   async function handleSignIn() {
-    setError(null);
-    setSession(null);
-    setStatus("connecting");
+    const nextSession = await connect();
 
-    try {
-      const { StellarWalletsKit, Networks } =
-        await import("@creit.tech/stellar-wallets-kit");
-      const { defaultModules } =
-        await import("@creit.tech/stellar-wallets-kit/modules/utils");
-      const { FREIGHTER_ID } =
-        await import("@creit.tech/stellar-wallets-kit/modules/freighter");
-
-      StellarWalletsKit.init({
-        network: Networks.TESTNET,
-        selectedWalletId: FREIGHTER_ID,
-        modules: defaultModules(),
-      });
-
-      const { address } = await StellarWalletsKit.authModal();
-
-      if (!address) {
-        throw new Error("No wallet address was returned by the wallet.");
-      }
-
-      const challenge = createChallenge(address);
-
-      setStatus("signing");
-
-      const signature = await StellarWalletsKit.signMessage(challenge, {
-        address,
-        networkPassphrase: Networks.TESTNET,
-      });
-
-      // if (!signature.signedMessage) {
-      //   throw new Error("The wallet did not return a signed message.");
-      // }
-
-      // const verified = await verifySignedMessage(
-      //   challenge,
-      //   signature.signedMessage,
-      //   signature.signerAddress ?? address,
-      // );
-
-      // if (!verified) {
-      //   throw new Error("Signature verification failed. Please try again.");
-      // }
-
-      const nextSession = {
-        address,
-        challenge,
-        signature: signature.signedMessage,
-        signedAt: new Date().toISOString(),
-      };
-
-      sessionStorage.setItem(MERCHANT_SESSION_KEY, JSON.stringify(nextSession));
-      setSession(nextSession);
-      setStatus("verified");
-
-      const profile = getMerchantProfile(address);
-      router.push(profile?.emailVerified ? "/dashboard" : "/register");
-    } catch (signInError) {
-      setStatus("error");
-      setError(
-        signInError instanceof Error
-          ? signInError.message
-          : "Unable to verify the connected wallet.",
-      );
+    if (!nextSession) {
+      return;
     }
+
+    const profile = getMerchantProfile(nextSession.address);
+    router.push(profile?.emailVerified ? "/dashboard" : "/register");
   }
 
   return (
@@ -167,21 +54,7 @@ export function SignInClient() {
             </div>
           ) : null}
 
-          <Button
-            className="w-full"
-            size="lg"
-            onClick={handleSignIn}
-            disabled={status === "connecting" || status === "signing"}
-          >
-            {status === "connecting" || status === "signing" ? (
-              <Loader2 className="animate-spin" />
-            ) : status === "verified" ? (
-              <BadgeCheck />
-            ) : (
-              <WalletCards />
-            )}
-            {buttonLabel}
-          </Button>
+          <WalletConnectButton status={status} onClick={handleSignIn} />
         </div>
       </section>
     </main>

--- a/src/components/Topbar.tsx
+++ b/src/components/Topbar.tsx
@@ -1,24 +1,15 @@
 "use client";
 
-import { useEffect, useState } from "react";
 import { Moon, Sun, Wallet } from "lucide-react";
 
 import { MobileNav } from "@/components/MobileNav";
 import { useTheme } from "@/components/ThemeProvider";
-import { getMerchantSessionAddress } from "@/lib/merchant-storage";
-
-function truncateAddress(address: string): string {
-  if (address.length <= 10) return address;
-  return `${address.slice(0, 4)}...${address.slice(-4)}`;
-}
+import { WalletAddressBadge } from "@/components/wallet-address-badge";
+import { useMerchantSession } from "@/hooks/use-merchant-session";
 
 export function Topbar() {
   const { isDark, toggleTheme } = useTheme();
-  const [walletAddress, setWalletAddress] = useState<string | null>(null);
-
-  useEffect(() => {
-    setWalletAddress(getMerchantSessionAddress());
-  }, []);
+  const { address: walletAddress } = useMerchantSession();
 
   return (
     <header className="fixed inset-x-0 top-0 z-30 ml-0 flex h-16 items-center justify-between border-b bg-background px-6 md:ml-60">
@@ -28,11 +19,12 @@ export function Topbar() {
 
       <div className="flex items-center gap-3">
         {walletAddress ? (
-          <div className="flex items-center gap-2 rounded-md border bg-secondary/60 px-3 py-1.5">
+          <div className="flex items-center gap-2">
             <Wallet className="size-3.5 shrink-0 text-muted-foreground" />
-            <span className="font-mono text-xs font-medium text-secondary-foreground">
-              {truncateAddress(walletAddress)}
-            </span>
+            <WalletAddressBadge
+              address={walletAddress}
+              className="bg-secondary/60 font-medium text-secondary-foreground"
+            />
           </div>
         ) : null}
 

--- a/src/components/require-wallet-session.test.tsx
+++ b/src/components/require-wallet-session.test.tsx
@@ -1,0 +1,47 @@
+import { render, screen, waitFor } from "@testing-library/react";
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+import { MERCHANT_SESSION_KEY } from "@/lib/merchant-storage";
+import { RequireWalletSession } from "./require-wallet-session";
+
+const replace = vi.fn();
+
+vi.mock("next/navigation", () => ({
+  useRouter: () => ({ replace }),
+}));
+
+describe("RequireWalletSession", () => {
+  beforeEach(() => {
+    replace.mockClear();
+    sessionStorage.clear();
+  });
+
+  it("redirects to sign-in when there is no session", async () => {
+    render(
+      <RequireWalletSession>
+        <p>Dashboard content</p>
+      </RequireWalletSession>,
+    );
+
+    await waitFor(() => expect(replace).toHaveBeenCalledWith("/sign-in"));
+    expect(screen.queryByText("Dashboard content")).not.toBeInTheDocument();
+  });
+
+  it("renders children when a session exists", async () => {
+    sessionStorage.setItem(
+      MERCHANT_SESSION_KEY,
+      JSON.stringify({ address: "GABC1234" }),
+    );
+
+    render(
+      <RequireWalletSession>
+        <p>Dashboard content</p>
+      </RequireWalletSession>,
+    );
+
+    await waitFor(() =>
+      expect(screen.getByText("Dashboard content")).toBeInTheDocument(),
+    );
+    expect(replace).not.toHaveBeenCalled();
+  });
+});

--- a/src/components/require-wallet-session.tsx
+++ b/src/components/require-wallet-session.tsx
@@ -1,0 +1,43 @@
+"use client";
+
+import { useEffect, type ReactNode } from "react";
+import { useRouter } from "next/navigation";
+import { Loader2 } from "lucide-react";
+
+import { useMerchantSession } from "@/hooks/use-merchant-session";
+
+interface RequireWalletSessionProps {
+  children: ReactNode;
+  /** Where unauthenticated visitors are sent. */
+  redirectTo?: string;
+}
+
+export function RequireWalletSession({
+  children,
+  redirectTo = "/sign-in",
+}: RequireWalletSessionProps) {
+  const router = useRouter();
+  const { address, isLoading } = useMerchantSession();
+
+  useEffect(() => {
+    if (isLoading || address) {
+      return;
+    }
+
+    router.replace(redirectTo);
+  }, [address, isLoading, redirectTo, router]);
+
+  if (isLoading || !address) {
+    return (
+      <div
+        className="flex min-h-64 items-center justify-center"
+        role="status"
+        aria-label="Checking wallet session"
+      >
+        <Loader2 className="size-6 animate-spin text-primary" />
+      </div>
+    );
+  }
+
+  return <>{children}</>;
+}

--- a/src/components/wallet-address-badge.test.tsx
+++ b/src/components/wallet-address-badge.test.tsx
@@ -1,0 +1,53 @@
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, it, expect, vi } from "vitest";
+
+import { WalletAddressBadge, truncateAddress } from "./wallet-address-badge";
+
+const ADDRESS = "GABC1234567890ABCDEFGHIJKLMNOPQRSTUVWXYZ1234";
+
+describe("truncateAddress", () => {
+  it("keeps leading and trailing characters", () => {
+    expect(truncateAddress(ADDRESS)).toBe("GABC...1234");
+  });
+
+  it("respects custom character counts", () => {
+    expect(truncateAddress(ADDRESS, 6, 6)).toBe(
+      `${ADDRESS.slice(0, 6)}...${ADDRESS.slice(-6)}`,
+    );
+  });
+
+  it("returns short addresses unchanged", () => {
+    expect(truncateAddress("GABC1234")).toBe("GABC1234");
+  });
+});
+
+describe("WalletAddressBadge", () => {
+  it("renders the truncated address", () => {
+    render(<WalletAddressBadge address={ADDRESS} />);
+    expect(screen.getByText("GABC...1234")).toBeInTheDocument();
+  });
+
+  it("copies the full address and shows feedback", async () => {
+    const user = userEvent.setup();
+
+    const writeText = vi.fn().mockResolvedValue(undefined);
+    Object.defineProperty(navigator, "clipboard", {
+      configurable: true,
+      value: { writeText },
+    });
+
+    render(<WalletAddressBadge address={ADDRESS} />);
+
+    await user.click(
+      screen.getByRole("button", { name: /copy wallet address/i }),
+    );
+
+    expect(writeText).toHaveBeenCalledWith(ADDRESS);
+    await waitFor(() =>
+      expect(
+        screen.getByRole("button", { name: /address copied/i }),
+      ).toBeInTheDocument(),
+    );
+  });
+});

--- a/src/components/wallet-address-badge.tsx
+++ b/src/components/wallet-address-badge.tsx
@@ -1,0 +1,87 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { Check, Copy } from "lucide-react";
+
+import { Button } from "@/components/ui/button";
+import { cn } from "@/lib/utils";
+
+interface WalletAddressBadgeProps {
+  /** Full Stellar address. */
+  address: string;
+  /** Characters kept from the start of the address. */
+  leadingChars?: number;
+  /** Characters kept from the end of the address. */
+  trailingChars?: number;
+  /** Class hook for callers. */
+  className?: string;
+}
+
+export function truncateAddress(
+  address: string,
+  leadingChars = 4,
+  trailingChars = 4,
+) {
+  if (address.length <= leadingChars + trailingChars) {
+    return address;
+  }
+
+  return `${address.slice(0, leadingChars)}...${address.slice(-trailingChars)}`;
+}
+
+export function WalletAddressBadge({
+  address,
+  leadingChars = 4,
+  trailingChars = 4,
+  className,
+}: WalletAddressBadgeProps) {
+  const [copied, setCopied] = useState(false);
+
+  useEffect(() => {
+    if (!copied) return;
+    const timeout = window.setTimeout(() => setCopied(false), 1500);
+    return () => window.clearTimeout(timeout);
+  }, [copied]);
+
+  async function handleCopy() {
+    try {
+      if (typeof navigator !== "undefined" && navigator.clipboard?.writeText) {
+        await navigator.clipboard.writeText(address);
+      } else {
+        const textarea = document.createElement("textarea");
+        textarea.value = address;
+        document.body.appendChild(textarea);
+        textarea.select();
+        document.execCommand("copy");
+        document.body.removeChild(textarea);
+      }
+      setCopied(true);
+    } catch {
+      // Silently fail — the full address stays selectable via the title.
+    }
+  }
+
+  return (
+    <span
+      className={cn(
+        "inline-flex items-center gap-1 rounded-md border bg-muted/30 py-1 pl-2 pr-1 text-xs font-mono",
+        className,
+      )}
+    >
+      <span title={address}>
+        {truncateAddress(address, leadingChars, trailingChars)}
+      </span>
+      <Button
+        type="button"
+        variant="ghost"
+        size="sm"
+        onClick={handleCopy}
+        aria-label={copied ? "Address copied" : "Copy wallet address"}
+        aria-live="polite"
+        className="size-6 p-0 [&_svg]:size-3"
+      >
+        {copied ? <Check /> : <Copy />}
+      </Button>
+    </span>
+  );
+}

--- a/src/components/wallet-connect-button.test.tsx
+++ b/src/components/wallet-connect-button.test.tsx
@@ -1,0 +1,42 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, it, expect, vi } from "vitest";
+
+import { WalletConnectButton } from "./wallet-connect-button";
+
+describe("WalletConnectButton", () => {
+  it("shows the idle label and fires onClick", async () => {
+    const onClick = vi.fn();
+    const user = userEvent.setup();
+
+    render(<WalletConnectButton status="idle" onClick={onClick} />);
+
+    const button = screen.getByRole("button", {
+      name: /connect wallet to sign in/i,
+    });
+    await user.click(button);
+
+    expect(onClick).toHaveBeenCalledTimes(1);
+  });
+
+  it("disables itself while connecting or signing", () => {
+    const { rerender } = render(
+      <WalletConnectButton status="connecting" onClick={vi.fn()} />,
+    );
+    expect(
+      screen.getByRole("button", { name: /connecting wallet/i }),
+    ).toBeDisabled();
+
+    rerender(<WalletConnectButton status="signing" onClick={vi.fn()} />);
+    expect(
+      screen.getByRole("button", { name: /waiting for signature/i }),
+    ).toBeDisabled();
+  });
+
+  it("shows the verified label once verified", () => {
+    render(<WalletConnectButton status="verified" onClick={vi.fn()} />);
+    expect(
+      screen.getByRole("button", { name: /wallet verified/i }),
+    ).toBeEnabled();
+  });
+});

--- a/src/components/wallet-connect-button.tsx
+++ b/src/components/wallet-connect-button.tsx
@@ -1,0 +1,57 @@
+"use client";
+
+import { BadgeCheck, Loader2, WalletCards } from "lucide-react";
+
+import { Button } from "@/components/ui/button";
+import type { WalletConnectStatus } from "@/hooks/use-wallet-connect";
+import { cn } from "@/lib/utils";
+
+interface WalletConnectButtonProps {
+  /** Current state of the connect/sign flow. */
+  status: WalletConnectStatus;
+  /** Starts the connect/sign flow. */
+  onClick: () => void;
+  /** Class hook for callers. */
+  className?: string;
+}
+
+const LABELS: Record<WalletConnectStatus, string> = {
+  idle: "Connect wallet to sign in",
+  connecting: "Connecting wallet",
+  signing: "Waiting for signature",
+  verified: "Wallet verified",
+  error: "Connect wallet to sign in",
+};
+
+function StatusIcon({ status }: { status: WalletConnectStatus }) {
+  if (status === "connecting" || status === "signing") {
+    return <Loader2 className="animate-spin" />;
+  }
+
+  if (status === "verified") {
+    return <BadgeCheck />;
+  }
+
+  return <WalletCards />;
+}
+
+export function WalletConnectButton({
+  status,
+  onClick,
+  className,
+}: WalletConnectButtonProps) {
+  const isBusy = status === "connecting" || status === "signing";
+
+  return (
+    <Button
+      type="button"
+      className={cn("w-full", className)}
+      size="lg"
+      onClick={onClick}
+      disabled={isBusy}
+    >
+      <StatusIcon status={status} />
+      {LABELS[status]}
+    </Button>
+  );
+}

--- a/src/hooks/use-merchant-session.ts
+++ b/src/hooks/use-merchant-session.ts
@@ -1,0 +1,25 @@
+"use client";
+
+import { useEffect, useState } from "react";
+
+import { getMerchantSessionAddress } from "@/lib/merchant-storage";
+
+export type MerchantSessionState = {
+  /** Wallet address of the signed-in merchant, null when unauthenticated. */
+  address: string | null;
+  /** True until the sessionStorage check has run on the client. */
+  isLoading: boolean;
+};
+
+export function useMerchantSession(): MerchantSessionState {
+  const [state, setState] = useState<MerchantSessionState>({
+    address: null,
+    isLoading: true,
+  });
+
+  useEffect(() => {
+    setState({ address: getMerchantSessionAddress(), isLoading: false });
+  }, []);
+
+  return state;
+}

--- a/src/hooks/use-wallet-connect.ts
+++ b/src/hooks/use-wallet-connect.ts
@@ -1,0 +1,104 @@
+"use client";
+
+import { useCallback, useState } from "react";
+
+import { MERCHANT_SESSION_KEY } from "@/lib/merchant-storage";
+
+export type WalletConnectStatus =
+  | "idle"
+  | "connecting"
+  | "signing"
+  | "verified"
+  | "error";
+
+export type WalletSession = {
+  address: string;
+  challenge: string;
+  signature: string;
+  signedAt: string;
+};
+
+export function createChallenge(address: string) {
+  const issuedAt = new Date().toISOString();
+  const nonce =
+    typeof crypto !== "undefined" && "randomUUID" in crypto
+      ? crypto.randomUUID()
+      : `${Date.now()}-${Math.random().toString(16).slice(2)}`;
+
+  return [
+    "Shade Merchant Sign In",
+    "",
+    "Sign this message to prove you control this Stellar wallet.",
+    "This request will not move funds or create a transaction.",
+    "",
+    `Wallet: ${address}`,
+    `Nonce: ${nonce}`,
+    `Issued At: ${issuedAt}`,
+  ].join("\n");
+}
+
+export function useWalletConnect() {
+  const [status, setStatus] = useState<WalletConnectStatus>("idle");
+  const [error, setError] = useState<string | null>(null);
+  const [session, setSession] = useState<WalletSession | null>(null);
+
+  const connect = useCallback(async () => {
+    setError(null);
+    setSession(null);
+    setStatus("connecting");
+
+    try {
+      const { StellarWalletsKit, Networks } =
+        await import("@creit.tech/stellar-wallets-kit");
+      const { defaultModules } =
+        await import("@creit.tech/stellar-wallets-kit/modules/utils");
+      const { FREIGHTER_ID } =
+        await import("@creit.tech/stellar-wallets-kit/modules/freighter");
+
+      StellarWalletsKit.init({
+        network: Networks.TESTNET,
+        selectedWalletId: FREIGHTER_ID,
+        modules: defaultModules(),
+      });
+
+      const { address } = await StellarWalletsKit.authModal();
+
+      if (!address) {
+        throw new Error("No wallet address was returned by the wallet.");
+      }
+
+      const challenge = createChallenge(address);
+
+      setStatus("signing");
+
+      const signature = await StellarWalletsKit.signMessage(challenge, {
+        address,
+        networkPassphrase: Networks.TESTNET,
+      });
+
+      const nextSession: WalletSession = {
+        address,
+        challenge,
+        signature: signature.signedMessage,
+        signedAt: new Date().toISOString(),
+      };
+
+      sessionStorage.setItem(MERCHANT_SESSION_KEY, JSON.stringify(nextSession));
+      setSession(nextSession);
+      setStatus("verified");
+
+      return nextSession;
+    } catch (connectError) {
+      setStatus("error");
+      setError(
+        connectError instanceof Error
+          ? connectError.message
+          : "Unable to verify the connected wallet.",
+      );
+
+      return null;
+    }
+  }, []);
+
+  return { status, error, session, connect };
+}


### PR DESCRIPTION
## Summary

Extracts the wallet connect/sign flow out of `SignInClient` into reusable, independently testable pieces, and adds an auth guard for authenticated routes.

## Changes

### `useWalletConnect` hook — #110
- New `src/hooks/use-wallet-connect.ts` holding all Stellar Wallets Kit setup, `authModal()` connection, challenge creation, and `signMessage()` signing (previously inlined at `sign-in-client.tsx` lines 68–137).
- Returns `{ status, error, session, connect }`. `connect()` resolves to the new session on success or `null` on failure, so callers can branch on the result instead of watching state.
- `createChallenge` and the `WalletConnectStatus` / `WalletSession` types are exported from the hook module.
- `SignInClient` now consumes the hook; the post-sign-in redirect (`/dashboard` vs `/register` based on `emailVerified`) stays in the page component where it belongs.

### `WalletConnectButton` — #111
- New `src/components/wallet-connect-button.tsx` encapsulating the `Loader2` / `WalletCards` / `BadgeCheck` icon swap and label swap, plus the disabled-while-busy behavior.
- Takes `status` and `onClick`. `SignInClient` was refactored to use it — same labels, same icons, same disabled states, no visible behavior change.

### `WalletAddressBadge` — #114
- New `src/components/wallet-address-badge.tsx` rendering a full address truncated as `GABC...1234`, with a click-to-copy icon button and ~1.5s `Check` feedback.
- `leadingChars` / `trailingChars` are configurable; the exported `truncateAddress` helper is reusable on its own.
- Uses the async Clipboard API with a textarea + `execCommand` fallback for insecure contexts, matching the existing `CopyReadonlyInput` pattern.
- `Topbar` now uses this component, replacing its local duplicate `truncateAddress` — the topbar wallet chip gains copy support.

### `RequireWalletSession` guard — #113
- New `src/hooks/use-merchant-session.ts` exposing `{ address, isLoading }` from `sessionStorage`, so the "redirect if no session" pattern from `RegisterClient` no longer needs repeating per route.
- New `src/components/require-wallet-session.tsx` rendering a spinner until the session check resolves, then either its children or a `router.replace()` to `/sign-in` (`redirectTo` is overridable).
- Applied to the dashboard page (`src/app/(dashboard)/dashboard/page.tsx`), which previously had no auth guard. Unauthenticated visitors go to `/sign-in`; authenticated visitors see the existing dashboard content unchanged.

## Tests

Added Vitest + Testing Library coverage for all three new components:
- `wallet-address-badge.test.tsx` — truncation (default, custom counts, short address passthrough), clipboard write of the **full** address, copy feedback.
- `wallet-connect-button.test.tsx` — idle label + `onClick`, disabled during `connecting` / `signing`, verified label.
- `require-wallet-session.test.tsx` — redirects to `/sign-in` with no session, renders children when a session exists.

## Verification

- `npm run typecheck` — clean.
- `npx vitest run` — 37 tests / 10 files passing.
- `npm run lint` — 4 errors, identical to the `main` baseline (all in pre-existing files: `payment/[id]/page.tsx`, `InvoiceRowActions.test.tsx`, `ProfileDetailsForm.test.tsx`, `api-key-reveal.tsx`). No new lint issues introduced by this branch.

Closes #110
Closes #111
Closes #113
Closes #114
