### PR TITLE
feat: add global loading, error, not-found states and reusable Logo component

### DIFF
--- a/src/app/error.tsx
+++ b/src/app/error.tsx
@@ -1,0 +1,56 @@
+"use client";
+
+import { useEffect } from "react";
+import { AlertTriangle, RotateCcw } from "lucide-react";
+
+import { Button } from "@/components/ui/button";
+import { Logo } from "@/components/logo";
+
+export default function Error({
+  error,
+  reset,
+}: {
+  error: Error & { digest?: string };
+  reset: () => void;
+}) {
+  useEffect(() => {
+    console.error(error);
+  }, [error]);
+
+  return (
+    <main className="flex min-h-screen items-center justify-center bg-background px-6 py-12 text-foreground">
+      <section className="w-full max-w-md">
+        <div className="mb-8 text-center">
+          <div className="mx-auto flex size-12 items-center justify-center rounded-lg bg-destructive/10 text-destructive">
+            <AlertTriangle className="size-6" />
+          </div>
+          <h1 className="mt-5 text-3xl font-bold">Something went wrong</h1>
+          <p className="mt-2 text-sm leading-6 text-muted-foreground">
+            An unexpected error occurred while loading this page. You can try
+            again, or head back if the problem continues.
+          </p>
+        </div>
+
+        <div className="rounded-lg border bg-card p-6 shadow-sm">
+          <div className="mb-4 rounded-lg border border-destructive/30 bg-destructive/10 p-3 text-sm text-destructive">
+            {error.message || "Unknown error."}
+            {error.digest ? (
+              <p className="mt-2 break-all text-xs opacity-80">
+                Reference: {error.digest}
+              </p>
+            ) : null}
+          </div>
+
+          <Button className="w-full" size="lg" onClick={() => reset()}>
+            <RotateCcw />
+            Try again
+          </Button>
+        </div>
+
+        <div className="mt-8 flex justify-center">
+          <Logo size="sm" />
+        </div>
+      </section>
+    </main>
+  );
+}

--- a/src/app/loading.tsx
+++ b/src/app/loading.tsx
@@ -1,0 +1,14 @@
+import { Loader2 } from "lucide-react";
+
+export default function Loading() {
+  return (
+    <div
+      role="status"
+      aria-live="polite"
+      className="flex min-h-screen items-center justify-center bg-background px-6 py-12 text-foreground"
+    >
+      <Loader2 className="size-8 animate-spin text-primary" />
+      <span className="sr-only">Loading</span>
+    </div>
+  );
+}

--- a/src/app/not-found.tsx
+++ b/src/app/not-found.tsx
@@ -1,0 +1,45 @@
+import Link from "next/link";
+import { Compass, LayoutDashboard, LogIn } from "lucide-react";
+
+import { Button } from "@/components/ui/button";
+import { Logo } from "@/components/logo";
+
+export default function NotFound() {
+  return (
+    <main className="flex min-h-screen items-center justify-center bg-background px-6 py-12 text-foreground">
+      <section className="w-full max-w-md">
+        <div className="mb-8 text-center">
+          <div className="mx-auto flex size-12 items-center justify-center rounded-lg bg-secondary text-secondary-foreground">
+            <Compass className="size-6" />
+          </div>
+          <p className="mt-5 text-sm font-semibold text-primary">404</p>
+          <h1 className="mt-1 text-3xl font-bold">Page not found</h1>
+          <p className="mt-2 text-sm leading-6 text-muted-foreground">
+            The page you are looking for does not exist or may have been moved.
+          </p>
+        </div>
+
+        <div className="rounded-lg border bg-card p-6 shadow-sm">
+          <div className="flex flex-col gap-3">
+            <Button className="w-full" size="lg" asChild>
+              <Link href="/dashboard">
+                <LayoutDashboard />
+                Go to dashboard
+              </Link>
+            </Button>
+            <Button className="w-full" size="lg" variant="outline" asChild>
+              <Link href="/sign-in">
+                <LogIn />
+                Sign in
+              </Link>
+            </Button>
+          </div>
+        </div>
+
+        <div className="mt-8 flex justify-center">
+          <Logo size="sm" />
+        </div>
+      </section>
+    </main>
+  );
+}

--- a/src/app/payment/[id]/page.tsx
+++ b/src/app/payment/[id]/page.tsx
@@ -13,7 +13,7 @@ import { Loader2 } from "lucide-react";
 
 // Mock API service to fetch invoice by ID
 const fetchMockInvoice = async (id: string): Promise<InvoiceData> => {
-  return new Promise((resolve, reject) => {
+  return new Promise((resolve) => {
     setTimeout(() => {
       if (id === "invalid") {
         resolve({

--- a/src/components/invoices/InvoiceRowActions.test.tsx
+++ b/src/components/invoices/InvoiceRowActions.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen, waitFor } from "@testing-library/react";
+import { render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { describe, it, expect, vi } from "vitest";
 import { InvoiceRowActions } from "./InvoiceRowActions";

--- a/src/components/logo.tsx
+++ b/src/components/logo.tsx
@@ -1,0 +1,57 @@
+import Image from "next/image";
+
+import { cn } from "@/lib/utils";
+
+type LogoSize = "sm" | "md" | "lg";
+
+const SIZES: Record<LogoSize, { mark: number; gap: string; wordmark: string }> =
+  {
+    sm: { mark: 24, gap: "gap-2", wordmark: "text-sm" },
+    md: { mark: 28, gap: "gap-2.5", wordmark: "text-base" },
+    lg: { mark: 32, gap: "gap-2.5", wordmark: "text-xl" },
+  };
+
+type LogoProps = {
+  size?: LogoSize;
+  showWordmark?: boolean;
+  className?: string;
+  wordmarkClassName?: string;
+  priority?: boolean;
+};
+
+export function Logo({
+  size = "md",
+  showWordmark = true,
+  className,
+  wordmarkClassName,
+  priority = false,
+}: LogoProps) {
+  const { mark, gap, wordmark } = SIZES[size];
+
+  return (
+    <span className={cn("inline-flex items-center", gap, className)}>
+      <Image
+        src="/shade_logo_transparent.png"
+        alt={showWordmark ? "" : "Shade"}
+        aria-hidden={showWordmark || undefined}
+        width={mark}
+        height={mark}
+        priority={priority}
+        className="shrink-0"
+      />
+      {showWordmark ? (
+        <span
+          className={cn(
+            "font-bold tracking-tight text-foreground",
+            wordmark,
+            wordmarkClassName,
+          )}
+        >
+          Shade
+        </span>
+      ) : null}
+    </span>
+  );
+}
+
+export type { LogoProps, LogoSize };

--- a/src/components/profile/ProfileDetailsForm.test.tsx
+++ b/src/components/profile/ProfileDetailsForm.test.tsx
@@ -79,7 +79,7 @@ describe("ProfileDetailsForm", () => {
 
     expect(screen.getByRole("button", { name: "Saving..." })).toBeDisabled();
 
-    // @ts-ignore - resolveSubmit is assigned synchronously in the mock
+    // @ts-expect-error - resolveSubmit is assigned synchronously in the mock
     resolveSubmit();
 
     await waitFor(() => {

--- a/src/components/ui/api-key-reveal.tsx
+++ b/src/components/ui/api-key-reveal.tsx
@@ -29,7 +29,7 @@ export function ApiKeyReveal({
       await navigator.clipboard.writeText(apiKey);
       setCopied(true);
       toast.success("API key copied to clipboard!");
-    } catch (error) {
+    } catch {
       toast.error("Failed to copy API key.");
     }
   };

--- a/src/lib/lucide-react.tsx
+++ b/src/lib/lucide-react.tsx
@@ -445,6 +445,34 @@ export function RefreshCw(props: IconProps) {
   );
 }
 
+export function RotateCcw(props: IconProps) {
+  return (
+    <IconBase {...props}>
+      <path d="M3 2v6h6" />
+      <path d="M3.5 13a9 9 0 1 0 2.6-6.4L3 8" />
+    </IconBase>
+  );
+}
+
+export function Compass(props: IconProps) {
+  return (
+    <IconBase {...props}>
+      <circle cx="12" cy="12" r="10" />
+      <path d="m16.2 7.8-2.9 6.5-6.5 2.9 2.9-6.5 6.5-2.9Z" />
+    </IconBase>
+  );
+}
+
+export function LogIn(props: IconProps) {
+  return (
+    <IconBase {...props}>
+      <path d="M15 3h4a2 2 0 0 1 2 2v14a2 2 0 0 1-2 2h-4" />
+      <path d="m10 17 5-5-5-5" />
+      <path d="M15 12H3" />
+    </IconBase>
+  );
+}
+
 export function Settings(props: IconProps) {
   return (
     <IconBase {...props}>


### PR DESCRIPTION
## Summary

Adds the three global Next.js App Router route-state conventions and a reusable brand `Logo` component. None of these existed in `src/app/` before, so unmatched routes, slow navigations, and render errors all fell back to Next's default unstyled UI.

All four screens reuse the existing centered full-screen layout pattern from `sign-in-client.tsx` (`bg-background` / `max-w-md` / `rounded-lg border bg-card p-6 shadow-sm`) so they read as part of the app.

## Issues

Closes #106
Closes #107
Closes #108
Closes #109

## Changes

### `src/components/logo.tsx` (#109)
Reusable brand mark rendering `/shade_logo_transparent.png` alongside the "Shade" wordmark.

- `size` prop — `sm` (24px), `md` (28px, default), `lg` (32px). The `md` and `lg` values match the sizes already hardcoded in `Sidebar.tsx` / `MobileNav.tsx` (28px) and `PublicPaymentLayout.tsx` (32px), so it is a drop-in for all existing call sites.
- **No layout shift:** `next/image` receives explicit `width`/`height` per size and the wordmark uses a fixed text size, so the box is reserved before the image loads.
- `showWordmark={false}` renders the mark alone for tight spaces (mobile nav, future public payment header).
- Accessibility: with the wordmark visible the image is `aria-hidden` with an empty `alt` to avoid announcing "Shade" twice; mark-only mode carries `alt="Shade"`.
- Accepts `className` / `wordmarkClassName` (merged via `cn`) so contexts like the sidebar can apply `text-sidebar-foreground`.

### `src/app/loading.tsx` (#106)
Centered `Loader2` + `animate-spin` fallback matching the spinner pattern in `sign-in-client.tsx` and `register-client.tsx`. Marked `role="status"` / `aria-live="polite"` with an `sr-only` "Loading" label.

### `src/app/error.tsx` (#107)
Client component implementing Next's error boundary contract (`error`, `reset`).

- Logs the error via `useEffect`.
- Shows the message in the destructive alert treatment already used for the sign-in error state, plus `error.digest` when present for support correlation.
- "Try again" `Button` wired to `reset()`.

### `src/app/not-found.tsx` (#108)
Themed 404. Offers both a primary "Go to dashboard" link and an outline "Sign in" link — as a server component it cannot read the client-side wallet session, so it exposes both paths rather than guessing auth state.

### `src/lib/lucide-react.tsx` (supporting)
`tsconfig.json` maps `lucide-react` to this vendored shim, which only exports a hand-maintained subset of icons. Added `RotateCcw`, `Compass`, and `LogIn` in the existing `IconBase` style to support the new screens.

## Verification

- `npm run typecheck` — passes clean
- `npm run lint` — no errors (2 pre-existing `<img>` warnings remain, non-blocking)
- `npx prettier --check` on all touched files — passes
- `npm run build` — **completes successfully**, all 16 routes generated including `/_not-found`
- `npx vitest run` — 27/27 tests passing across 7 files

## Testing notes

- Visit any unknown route (e.g. `/does-not-exist`) — themed 404 renders.
- Throw inside a page component — themed fallback renders and "Try again" recovers.
- `<Logo size="sm" />` is rendered at the foot of both the 404 and error screens.

## Note on the extra commit

The build's lint gate was already failing on `main` for four files unrelated to this feature work, which kept CI red. Since this PR could not otherwise go green, those are fixed here in a separate commit (`fix: resolve pre-existing lint errors blocking the build`). All four are no-op changes:

- `src/app/payment/[id]/page.tsx` — dropped unused `reject` param
- `src/components/invoices/InvoiceRowActions.test.tsx` — dropped unused `waitFor` import
- `src/components/profile/ProfileDetailsForm.test.tsx` — `@ts-ignore` → `@ts-expect-error`
- `src/components/ui/api-key-reveal.tsx` — optional catch binding for unused `error`

Happy to split these into their own PR if you'd rather keep this one scoped strictly to #106–#109.
