### PR TITLE
feat(ui): add Separator component using @radix-ui/react-separator

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Shade DApp Frontend
 
 The **Shade DApp Frontend** is the user interface for interacting with the Shade decentralized payment gateway. It allows merchants and customers to manage and process crypto payments through a simple, wallet-connected web application.
-
+jjn
 The frontend connects directly to the Shade smart contracts and backend services to enable invoice creation, payment processing, and real-time transaction updates.
 
 ## Features

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
         "@creit.tech/stellar-wallets-kit": "^2.0.0",
         "@radix-ui/react-dialog": "^1.1.15",
         "@radix-ui/react-dropdown-menu": "^2.1.16",
+        "@radix-ui/react-separator": "^1.1.15",
         "@radix-ui/react-slot": "^1.2.3",
         "@radix-ui/react-tabs": "^1.1.13",
         "@stellar/freighter-api": "^5.0.0",
@@ -2812,14 +2813,75 @@
         }
       }
     },
-    "node_modules/@radix-ui/react-slot": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-slot/-/react-slot-1.2.4.tgz",
-      "integrity": "sha512-Jl+bCv8HxKnlTLVrcDE8zTMJ09R9/ukw4qBs/oZClOfoQk/cOTbDn+NceXfV7j09YPVQUryJPHurafcSg6EVKA==",
+    "node_modules/@radix-ui/react-separator": {
+      "version": "1.1.15",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-separator/-/react-separator-1.1.15.tgz",
+      "integrity": "sha512-jOLO4lssEzWpoDu7G+Ze4VjwMRUBt291pnZD0gmalREZipnTX3wadQo7Fy48GCTfe14/YRN6rw/rOJqrE85Wxw==",
       "license": "MIT",
       "dependencies": {
-        "@radix-ui/react-compose-refs": "1.1.2"
+        "@radix-ui/react-primitive": "2.1.10"
       },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-separator/node_modules/@radix-ui/react-primitive": {
+      "version": "2.1.10",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-primitive/-/react-primitive-2.1.10.tgz",
+      "integrity": "sha512-MucOnzh6hR5mid6VpkbglRAMYMjKLqRnGBbjXkzjK52fuQDd1qbkx78a5P40mkcnVXJdEVxm26E9OPAiUq7nBg==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-slot": "1.3.3"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-slot": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-slot/-/react-slot-1.3.3.tgz",
+      "integrity": "sha512-qx7oqnYbxnK9kYI9m317qmFmEgo6ywqWvbTogdj7cL9p3/yx4M48p7Rnw5z3H890cL/ow/EeWJsuTykeZVXP5Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-compose-refs": "1.1.5"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-slot/node_modules/@radix-ui/react-compose-refs": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-compose-refs/-/react-compose-refs-1.1.5.tgz",
+      "integrity": "sha512-+48PbAAbq3didjJxa+OaWY2ZwgAKsNiRGyeHKszblZMQ+kcpd9pAaT11cMkGEie0vsOi3QdeTE6d5Fe3Gn61kA==",
+      "license": "MIT",
       "peerDependencies": {
         "@types/react": "*",
         "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "@creit.tech/stellar-wallets-kit": "^2.0.0",
     "@radix-ui/react-dialog": "^1.1.15",
     "@radix-ui/react-dropdown-menu": "^2.1.16",
+    "@radix-ui/react-separator": "^1.1.15",
     "@radix-ui/react-slot": "^1.2.3",
     "@radix-ui/react-tabs": "^1.1.13",
     "@stellar/freighter-api": "^5.0.0",

--- a/src/components/ui/separator.test.tsx
+++ b/src/components/ui/separator.test.tsx
@@ -1,0 +1,59 @@
+import { render, screen } from "@testing-library/react";
+import { describe, it, expect } from "vitest";
+import { Separator } from "./separator";
+
+describe("Separator", () => {
+  it("renders with horizontal orientation by default", () => {
+    render(<Separator data-testid="separator" />);
+
+    const separator = screen.getByTestId("separator");
+    expect(separator).toBeInTheDocument();
+    expect(separator).toHaveAttribute("data-orientation", "horizontal");
+    expect(separator.className).toContain("h-px");
+    expect(separator.className).toContain("w-full");
+  });
+
+  it("renders with vertical orientation when specified", () => {
+    render(<Separator orientation="vertical" data-testid="separator" />);
+
+    const separator = screen.getByTestId("separator");
+    expect(separator).toHaveAttribute("data-orientation", "vertical");
+    expect(separator.className).toContain("h-full");
+    expect(separator.className).toContain("w-px");
+  });
+
+  it("is decorative by default and hidden from the accessibility tree", () => {
+    render(<Separator data-testid="separator" />);
+
+    const separator = screen.getByTestId("separator");
+    expect(separator).toHaveAttribute("role", "none");
+    expect(screen.queryByRole("separator")).not.toBeInTheDocument();
+  });
+
+  it("exposes a separator role when decorative is false", () => {
+    render(<Separator decorative={false} />);
+
+    expect(screen.getByRole("separator")).toBeInTheDocument();
+  });
+
+  it("applies the shared border theme token", () => {
+    render(<Separator data-testid="separator" />);
+
+    expect(screen.getByTestId("separator").className).toContain("bg-border");
+  });
+
+  it("merges custom className with default styles", () => {
+    render(<Separator data-testid="separator" className="my-4" />);
+
+    const separator = screen.getByTestId("separator");
+    expect(separator.className).toContain("my-4");
+    expect(separator.className).toContain("bg-border");
+  });
+
+  it("forwards a ref to the underlying element", () => {
+    const ref = { current: null as HTMLDivElement | null };
+    render(<Separator ref={ref} />);
+
+    expect(ref.current).toBeInstanceOf(HTMLDivElement);
+  });
+});

--- a/src/components/ui/separator.tsx
+++ b/src/components/ui/separator.tsx
@@ -1,0 +1,30 @@
+import * as React from "react";
+import * as SeparatorPrimitive from "@radix-ui/react-separator";
+
+import { cn } from "@/lib/utils";
+
+const Separator = React.forwardRef<
+  React.ElementRef<typeof SeparatorPrimitive.Root>,
+  React.ComponentPropsWithoutRef<typeof SeparatorPrimitive.Root>
+>(
+  (
+    { className, orientation = "horizontal", decorative = true, ...props },
+    ref,
+  ) => (
+    <SeparatorPrimitive.Root
+      ref={ref}
+      data-slot="separator"
+      decorative={decorative}
+      orientation={orientation}
+      className={cn(
+        "shrink-0 bg-border",
+        orientation === "horizontal" ? "h-px w-full" : "h-full w-px",
+        className,
+      )}
+      {...props}
+    />
+  ),
+);
+Separator.displayName = SeparatorPrimitive.Root.displayName;
+
+export { Separator };


### PR DESCRIPTION
Closes #98

## Summary
Built a shared Separator component to replace ad hoc border-t classes used for card/section boundaries.

## Changes Made

### New Files
- src/components/ui/separator.tsx - Separator component using @radix-ui/react-separator

### Modified Files
- package.json - Added @radix-ui/react-separator dependency

## Implementation Details
- Wraps @radix-ui/react-separator with horizontal and vertical orientation support
- Renders a themed 1px divider
- Provides a reusable primitive for consistent section boundaries across the app

## Tests Added
- Unit tests for both horizontal and vertical orientations
- Verify correct 1px border rendering
- Verify orientation prop is respected

## How to Test
- Import Separator component and render with orientation="horizontal" and orientation="vertical"
- Verify correct rendering in both orientations
- Run npm test to confirm all tests pass